### PR TITLE
Typo in connector map

### DIFF
--- a/rml_noaka/PipingNetworkSegment.map.ttl
+++ b/rml_noaka/PipingNetworkSegment.map.ttl
@@ -63,9 +63,7 @@
     rr:termType rr:IRI;
     rr:class imf:Terminal
   ] ;
-    
-  rr:predicateObjectMap :hasNetworkSegmentConnector ;¨
-
+                                     
   rr:predicateObjectMap [
     rr:predicate imf:hasConnector;
     rr:termType rr:IRI;


### PR DESCRIPTION
There is a typo in the piping network segment map that prevents the mappings from running. I think this is the correct fix, at least it runs