### PR TITLE
Experimental setup of XSLT for mapping to IMF

### DIFF
--- a/xslt/dexpi2imf.xslt
+++ b/xslt/dexpi2imf.xslt
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- This is an experimental XSLT stylesheet for evaluation of the DEXPI to IMF transformation in RML vs. XSLT-->
+
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:imf="http://ns.imfid.org/imf#"

--- a/xslt/dexpi2imf.xslt
+++ b/xslt/dexpi2imf.xslt
@@ -20,24 +20,18 @@
         
     </xsl:template>
             
-    <xsl:template match="Equipment">
+    <xsl:template match="PlantModel/Equipment" name="EquipmentBlockMap">
         <rdf:Description>
             <xsl:attribute name="rdf:about">
                 <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', @ID)" />
             </xsl:attribute>
-            <rdf:type>
-                <imf:Block/>
-                <dexpi:Equipment/>
-            </rdf:type>
+            <rdf:type rdf:resource="imf:Block"/>
+            <rdf:type rdf:resource="dexpi:Equipment"/>
+            <rdfs:label>Equipment</rdfs:label>
             <imf:hasTerminal>
-                <rdf:Description>
-                    <xsl:attribute name="rdf:about">
+                    <xsl:attribute name="rdf:resource">
                         <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', Nozzle/@ID)" />
                     </xsl:attribute>
-                    <rdf:type>
-                        <imf:Terminal />
-                    </rdf:type>
-                </rdf:Description>
             </imf:hasTerminal>
             <rdfs:label>
                 <xsl:value-of select="GenericAttributes/GenericAttribute[@Name='TagNameAssignmentClass']/@Value" />
@@ -51,9 +45,8 @@
             <xsl:attribute name="rdf:about">
                 <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', ../../@ID, '-node', count(preceding-sibling::*))" />
             </xsl:attribute>
-            <rdf:type>
-                <imf:Terminal/>
-            </rdf:type>
+            <rdf:type rdf:resource="imf:Terminal" />
+            <rdfs:label>Piping Component Terminal</rdfs:label>
             <xsl:variable name="connectorId">
                 <xsl:if test="count(preceding-sibling::*) = 1">
                     <xsl:if test="../../preceding-sibling::PipingComponent">
@@ -69,7 +62,7 @@
                             <xsl:value-of select="concat(../../@ID , '-node2-connector')" />
                         </xsl:when>
                         <xsl:when test="../../../Connection/@ToID" >
-                            <xsl:value-of select="concat(../../../Connection/@ToID, '-node', ../../../Connection/@ToNode, '-connector')" />"
+                            <xsl:value-of select="concat(../../../Connection/@ToID, '-node', ../../../Connection/@ToNode, '-connector')" />
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:value-of select="concat(../../@ID , '-node2-connector')" />
@@ -78,37 +71,40 @@
                 </xsl:if>
             </xsl:variable>
             <imf:hasConnector>
-                <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', $connectorId)" />         
+                <xsl:attribute name="rdf:resource">
+                    <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', $connectorId)" />
+                </xsl:attribute>
             </imf:hasConnector>
         </rdf:Description>
         <xsl:apply-templates />
     </xsl:template>
     
     
-    <xsl:template match="//PipingNetworkSegment/PipingComponent | //PipingNetworkSegment/PropertyBreak">
+    <xsl:template match="//PipingNetworkSegment/PipingComponent | //PipingNetworkSegment/PropertyBreak" name="PipingComponentBlockMap">
         <rdf:Description>
             <xsl:attribute name="rdf:about">
                 <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', @ID)" />
             </xsl:attribute>
-            <rdf:type>
-                <imf:Block/>
-                <dexpi:PipingComponent/>
-            </rdf:type>
+            <rdf:type rdf:resource="imf:Block"/>
+            <rdf:type rdf:resource="dexpi:PipingComponent"/>
+            <rdfs:label>Piping Component</rdfs:label>
             <imf:partOf>
-                <rdf:Description>
-                    <xsl:attribute name="rdf:about">
+                    <xsl:attribute name="rdf:resource">
                         <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', ../@ID)" />
                     </xsl:attribute>
-                </rdf:Description>
             </imf:partOf>
             <rdfs:label>
                 <xsl:value-of select="GenericAttributes/GenericAttribute[@Name='ItemTagAssignmentClass']/@Value" />
             </rdfs:label>
             <imf:hasTerminal>
-<!--                <xsl:call-template name="PipingComponentTerminalMap " />-->
+                <xsl:attribute name="rdf:resource">
+                    <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', @ID, '-node', count(preceding-sibling::*))" />                    
+                </xsl:attribute>                
+
             </imf:hasTerminal>
         </rdf:Description>
-        
+        <xsl:apply-templates />
+
     </xsl:template>
     
 </xsl:stylesheet>   

--- a/xslt/dexpi2imf.xslt
+++ b/xslt/dexpi2imf.xslt
@@ -1,13 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns="http://www.w3.org/2000/svg"
                 xmlns:imf="http://ns.imfid.org/imf#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+                xmlns:dexpi="https://rdf.equinor.com/dexpi#"
 >
     <xsl:output method="xml" indent="yes" />
 
     <!-- Root template -->
-    <xsl:template match="//GenericAttributes/GenericAttribute">
+    <xsl:template match="/PlantModel">
+    <rdf:RDF  xmlns:imf="http://ns.imfid.org/imf#"
+              xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+              xmlns:dexpi="https://rdf.equinor.com/dexpi#"
+    >
+    
+            <xsl:apply-templates />
+    </rdf:RDF>
         
     </xsl:template>
+            
+    <xsl:template match="Equipment">
+        <rdf:Description>
+            <xsl:attribute name="rdf:about">
+                <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', @ID)" />
+            </xsl:attribute>
+            <rdf:type>
+                <imf:Block/>
+                <dexpi:Equipment/>
+            </rdf:type>
+            <imf:hasTerminal>
+                <rdf:Description>
+                    <xsl:attribute name="rdf:about">
+                        <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', Nozzle/@ID)" />
+                    </xsl:attribute>
+                    <rdf:type>
+                        <imf:Terminal />
+                    </rdf:type>
+                </rdf:Description>
+            </imf:hasTerminal>
+            <rdfs:label>
+                <xsl:value-of select="GenericAttributes/GenericAttribute[@Name='TagNameAssignmentClass']/@Value" />
+            </rdfs:label>
+        </rdf:Description>  
+    </xsl:template>
+    
+    
+    <xsl:template match="//PipingNetworkSegment/PipingComponent/ConnectionPoints/Node[@Type='process'] | //PipingNetworkSegment/PropertyBreak/ConnectionPoints/Node[@Type='process']">
+        <rdf:Description>
+            <xsl:attribute name="rdf:about">
+                <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', ../../@ID, '-node', count(preceding-sibling::*))" />
+            </xsl:attribute>
+            <rdf:type>
+                <imf:Terminal/>
+            </rdf:type>
+            <xsl:variable name="connectorId">
+                <xsl:if test="count(preceding-sibling::*) = 1">
+                    <xsl:if test="../../preceding-sibling::PipingComponent">
+                       <xsl:value-of select="concat(../../preceding-sibling::PipingComponent[1]/@ID, '-node2-connector')" />
+                    </xsl:if>
+                    <xsl:if test="../../../Connection/@FromID">
+                        <xsl:value-of select="concat(../../../Connection/@FromID, '-node',  ../../../Connection/@FromNode, '-connector')" />
+                    </xsl:if>
+                </xsl:if>
+                <xsl:if test="count(preceding-sibling::*) = 2">
+                    <xsl:choose>
+                        <xsl:when test="../../following-sibling::PipingComponent or following-sibling::PropertyBreak">
+                            <xsl:value-of select="concat(../../@ID , '-node2-connector')" />
+                        </xsl:when>
+                        <xsl:when test="../../../Connection/@ToID" >
+                            <xsl:value-of select="concat(../../../Connection/@ToID, '-node', ../../../Connection/@ToNode, '-connector')" />"
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="concat(../../@ID , '-node2-connector')" />
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:if>
+            </xsl:variable>
+            <imf:hasConnector>
+                <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', $connectorId)" />         
+            </imf:hasConnector>
+        </rdf:Description>
+    </xsl:template>
+    
 </xsl:stylesheet>   

--- a/xslt/dexpi2imf.xslt
+++ b/xslt/dexpi2imf.xslt
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://www.w3.org/2000/svg"
+                xmlns:imf="http://ns.imfid.org/imf#"
+>
+    <xsl:output method="xml" indent="yes" />
+
+    <!-- Root template -->
+    <xsl:template match="//GenericAttributes/GenericAttribute">
+        
+    </xsl:template>
+</xsl:stylesheet>   

--- a/xslt/dexpi2imf.xslt
+++ b/xslt/dexpi2imf.xslt
@@ -46,7 +46,7 @@
     </xsl:template>
     
     
-    <xsl:template match="//PipingNetworkSegment/PipingComponent/ConnectionPoints/Node[@Type='process'] | //PipingNetworkSegment/PropertyBreak/ConnectionPoints/Node[@Type='process']">
+    <xsl:template name="PipingComponentTerminalMap" match="//PipingNetworkSegment/PipingComponent/ConnectionPoints/Node[@Type='process'] | //PipingNetworkSegment/PropertyBreak/ConnectionPoints/Node[@Type='process']">
         <rdf:Description>
             <xsl:attribute name="rdf:about">
                 <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', ../../@ID, '-node', count(preceding-sibling::*))" />
@@ -81,6 +81,34 @@
                 <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', $connectorId)" />         
             </imf:hasConnector>
         </rdf:Description>
+        <xsl:apply-templates />
+    </xsl:template>
+    
+    
+    <xsl:template match="//PipingNetworkSegment/PipingComponent | //PipingNetworkSegment/PropertyBreak">
+        <rdf:Description>
+            <xsl:attribute name="rdf:about">
+                <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', @ID)" />
+            </xsl:attribute>
+            <rdf:type>
+                <imf:Block/>
+                <dexpi:PipingComponent/>
+            </rdf:type>
+            <imf:partOf>
+                <rdf:Description>
+                    <xsl:attribute name="rdf:about">
+                        <xsl:value-of select="concat('https://assetid.equinor.com/plantx#', ../@ID)" />
+                    </xsl:attribute>
+                </rdf:Description>
+            </imf:partOf>
+            <rdfs:label>
+                <xsl:value-of select="GenericAttributes/GenericAttribute[@Name='ItemTagAssignmentClass']/@Value" />
+            </rdfs:label>
+            <imf:hasTerminal>
+<!--                <xsl:call-template name="PipingComponentTerminalMap " />-->
+            </imf:hasTerminal>
+        </rdf:Description>
+        
     </xsl:template>
     
 </xsl:stylesheet>   


### PR DESCRIPTION
This is the XSLT stylesheet used to evaluate XSLT vs. RML for Dexpi 2 IMF mappings. I thought it could be nice to have in the repo for reference. Not sure though.