### PR TITLE
Default text angle 0

### DIFF
--- a/www/dexpisvg.xslt
+++ b/www/dexpisvg.xslt
@@ -549,7 +549,14 @@
                         name="posY" select="Text/Position/Location/@Y" />
                     <xsl:variable
                         name="textRotationAngle">
-                        <xsl:value-of select="Text/@TextAngle" />
+                        <xsl:choose>
+                            <xsl:when test="Text/@TextAngle">
+                                <xsl:value-of select="Text/@TextAngle" />
+                            </xsl:when>
+                            <xsl:otherwise>
+                                0
+                            </xsl:otherwise>
+                        </xsl:choose>
                     </xsl:variable>
                     <xsl:value-of
                         select="concat('rotate(', 360 - $textRotationAngle, ' ', $posX, ' ', $height - $posY, ')')" />


### PR DESCRIPTION
When the TextAngle attribute is not given on a Text tag, this PR sets the default angle to 0 (in stead of giving a NaN error)