### PR TITLE
Add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing
+## Contributing
 Please follow these steps to contribute:
 
 Fork the repository on GitHub. Clone your fork and create a new branch for your feature or bugfix. Commit your changes to the new branch. Push your changes to your fork. Open a pull request from your fork to the original repository. Please ensure that your code follows the existing style and structure, and add tests where necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+Please follow these steps to contribute:
+
+Fork the repository on GitHub. Clone your fork and create a new branch for your feature or bugfix. Commit your changes to the new branch. Push your changes to your fork. Open a pull request from your fork to the original repository. Please ensure that your code follows the existing style and structure, and add tests where necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,2 @@
 ## Contributing
-Please follow these steps to contribute:
-
-Fork the repository on GitHub. Clone your fork and create a new branch for your feature or bugfix. Commit your changes to the new branch. Push your changes to your fork. Open a pull request from your fork to the original repository. Please ensure that your code follows the existing style and structure, and add tests where necessary.
+This repo is in a very unfinished and experimental state. We do not encourage usage other than for experimentation, and we do not have capacity to handle contributions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+## SECURITY.md 
+
+If you discover a security vulnerability in this project, please follow the steps below to report it.
+
+### For "non-critical" issues
+
+- **Alternative A:**  
+Create a GitHub issue for the vulnerability. Avoid putting sensitive information in the issue.
+
+- **Alternative B:**  
+Send an email to the projects maintainer at [markp@equinor.com](mailto:markp@equinor.com) describing the issue.
+
+### For "critical" and time sensitive issues
+
+Phone the Equinor helpdesk:
+
+- Norway (+47) 51 999 222
+- US/Canada (+1) 713 878 6970

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,15 @@
 ## SECURITY.md 
 
-If you discover a security vulnerability in this project, please follow the steps below to report it.
+If you discover a security vulnerability in this project, please follow these steps to responsibly disclose it:
+1. Do not create a public GitHub issue for the vulnerability.
+2. Follow our guideline for Responsible Disclosure Policy at https://www.equinor.com/about-us/csirt to report the issue
 
-### For "non-critical" issues
-
-- **Alternative A:**  
-Create a GitHub issue for the vulnerability. Avoid putting sensitive information in the issue.
-
-- **Alternative B:**  
-Send an email to the projects maintainer at [markp@equinor.com](mailto:markp@equinor.com) describing the issue.
-
-### For "critical" and time sensitive issues
-
-Phone the Equinor helpdesk:
-
-- Norway (+47) 51 999 222
-- US/Canada (+1) 713 878 6970
+The following information will help us triage your report more quickly:
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+- We prefer all communications to be in English.


### PR DESCRIPTION
### [AB#198493](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/198493)
[Pull requests practices for the SSI team](https://github.com/equinor/ssi-infrastructure/blob/main/docs/pr_practices.md)

## Aim of the PR
In order to be compliant with Equinor requirements for GitHub repositories, we must have a SECURITY.md and CONTRIBUTING.md in our repo.

## Implementation 
I added a SECURITY.md and CONTRIBUTING.md
