### PR TITLE
Delete commissioning packages

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.eds.equinor.com/font/equinor-font.css" />
     <title>P&ID</title>
   </head>
   <body>

--- a/www/src/components/editor/CommissioningPackageDeletionDialog.tsx
+++ b/www/src/components/editor/CommissioningPackageDeletionDialog.tsx
@@ -44,31 +44,33 @@ const DeleteCommissioningPackageDialog: React.FC<DeleteDialogProps> = ({ isOpen,
       </Dialog.Header>
       <Dialog.CustomContent>
         Choose which commissioning packages to delete:
-        {context?.commissioningPackages.map((commpckg) => (
-          <Table key={commpckg.id}>
-            <Table.Row>
-              <Table.Cell>
-                <div style={{ display: 'flex', alignItems: 'center' }}>
-                  <div
-                    style={{
-                      width: '16px',
-                      height: '16px',
-                      backgroundColor: commpckg.color,
-                      borderRadius: '50%',
-                      marginRight: '8px',
-                    }}
-                  ></div>
-                  <Checkbox
-                    label={commpckg.name}
-                    name="multiple"
-                    checked={selectedPackages.has(commpckg.id)}
-                    onChange={() => handleCheckboxChange(commpckg.id)}
-                  />
-                </div>
-              </Table.Cell>
-            </Table.Row>
-          </Table>
-        ))}
+        <Table>
+          <Table.Body>
+            {context?.commissioningPackages.map((commpckg) => (
+                <Table.Row key={commpckg.id}>
+                  <Table.Cell>
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                      <div
+                          style={{
+                            width: '16px',
+                            height: '16px',
+                            backgroundColor: commpckg.color,
+                            borderRadius: '50%',
+                            marginRight: '8px',
+                          }}
+                      ></div>
+                      <Checkbox
+                          label={commpckg.name}
+                          name="multiple"
+                          checked={selectedPackages.has(commpckg.id)}
+                          onChange={() => handleCheckboxChange(commpckg.id)}
+                      />
+                    </div>
+                  </Table.Cell>
+                </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
       </Dialog.CustomContent>
       <Dialog.Actions>
         <Button onClick={handleDelete}>Delete</Button>

--- a/www/src/components/editor/CommissioningPackageDeletionDialog.tsx
+++ b/www/src/components/editor/CommissioningPackageDeletionDialog.tsx
@@ -29,6 +29,10 @@ const DeleteCommissioningPackageDialog: React.FC<DeleteDialogProps> = ({ isOpen,
     });
     onClose();
     setSelectedPackages(new Set());
+
+    if (context?.commissioningPackages.length === 0) {
+      context?.createInitialPackage();
+    }
   };
 
   useEffect(() => {

--- a/www/src/components/editor/CommissioningPackageDeletionDialog.tsx
+++ b/www/src/components/editor/CommissioningPackageDeletionDialog.tsx
@@ -1,0 +1,81 @@
+﻿import { Button, Checkbox, Dialog, Table } from "@equinor/eds-core-react";
+import React, { useEffect, useState } from "react";
+import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
+
+interface DeleteDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const DeleteCommissioningPackageDialog: React.FC<DeleteDialogProps> = ({ isOpen, onClose }) => {
+  const context = useCommissioningPackageContext();
+  const [selectedPackages, setSelectedPackages] = useState<Set<string>>(new Set());
+
+  const handleCheckboxChange = (packageId: string) => {
+    setSelectedPackages((prevSelected) => {
+      const newSelected = new Set(prevSelected);
+      if (newSelected.has(packageId)) {
+        newSelected.delete(packageId);
+      } else {
+        newSelected.add(packageId);
+      }
+      return newSelected;
+    });
+  };
+
+  const handleDelete = () => {
+    selectedPackages.forEach((packageId) => {
+      context?.deleteCommissioningPackage(packageId);
+    });
+    onClose();
+    setSelectedPackages(new Set());
+  };
+
+  useEffect(() => {
+    if (isOpen && context?.activePackage) {
+      setSelectedPackages(new Set([context.activePackage.id]));
+    }
+  }, [isOpen, context?.activePackage]);
+
+  return (
+    <Dialog open={isOpen} onClose={onClose}>
+      <Dialog.Header>
+        <Dialog.Title>Delete Commissioning Packages</Dialog.Title>
+      </Dialog.Header>
+      <Dialog.CustomContent>
+        Choose which commissioning packages to delete:
+        {context?.commissioningPackages.map((commpckg) => (
+          <Table key={commpckg.id}>
+            <Table.Row>
+              <Table.Cell>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <div
+                    style={{
+                      width: '16px',
+                      height: '16px',
+                      backgroundColor: commpckg.color,
+                      borderRadius: '50%',
+                      marginRight: '8px',
+                    }}
+                  ></div>
+                  <Checkbox
+                    label={commpckg.name}
+                    name="multiple"
+                    checked={selectedPackages.has(commpckg.id)}
+                    onChange={() => handleCheckboxChange(commpckg.id)}
+                  />
+                </div>
+              </Table.Cell>
+            </Table.Row>
+          </Table>
+        ))}
+      </Dialog.CustomContent>
+      <Dialog.Actions>
+        <Button onClick={handleDelete}>Delete</Button>
+        <Button variant="ghost" onClick={onClose}>Cancel</Button>
+      </Dialog.Actions>
+    </Dialog>
+  );
+};
+
+export default DeleteCommissioningPackageDialog;

--- a/www/src/components/editor/EditorSidebar.tsx
+++ b/www/src/components/editor/EditorSidebar.tsx
@@ -83,16 +83,26 @@ export default function EditorSidebar() {
         <Dialog.CustomContent>
           Choose which commissioning packages to delete:
           {context?.commissioningPackages.map((commpckg) => (
-              <Table>
+              <Table key={commpckg.id}>
                 <Table.Row>
                   <Table.Cell>
-                    <Checkbox
-                      key={commpckg.id}
-                      label={commpckg.name}
-                      name="multiple"
-                      checked={selectedPackages.has(commpckg.id)}
-                      onChange={() => handleCheckboxChange(commpckg.id)}
-                  />
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                      <div
+                          style={{
+                            width: '16px',
+                            height: '16px',
+                            backgroundColor: commpckg.color,
+                            borderRadius: '50%',
+                            marginRight: '8px',
+                          }}
+                      ></div>
+                      <Checkbox
+                          label={commpckg.name}
+                          name="multiple"
+                          checked={selectedPackages.has(commpckg.id)}
+                          onChange={() => handleCheckboxChange(commpckg.id)}
+                      />
+                    </div>
                   </Table.Cell>
                 </Table.Row>
               </Table>

--- a/www/src/components/editor/EditorSidebar.tsx
+++ b/www/src/components/editor/EditorSidebar.tsx
@@ -1,11 +1,12 @@
-import {Button, Checkbox, Dialog, SideBar, SidebarLinkProps, Table} from "@equinor/eds-core-react";
+import { SideBar, SidebarLinkProps } from "@equinor/eds-core-react";
 import { add, boundaries, category, texture, delete_to_trash } from "@equinor/eds-icons";
 import styled from "styled-components";
-import { useContext, useState, useEffect } from "react";
+import { useContext, useState } from "react";
 import Tools from "../../enums/Tools.ts";
 import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 import ToolContext from "../../context/ToolContext.ts";
 import CommissioningPackageCreationDialog from "./CommissioningPackageCreationDialog.tsx";
+import CommissioningPackageDeletionDialog from "./CommissioningPackageDeletionDialog.tsx";
 
 const StyledSideBar = styled.div`
   height: 100%;
@@ -16,33 +17,6 @@ export default function EditorSidebar() {
   const { activeTool, setActiveTool } = useContext(ToolContext);
   const [isCreationOpen, setIsCreationOpen] = useState<boolean>(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
-  const [selectedPackages, setSelectedPackages] = useState<Set<string>>(new Set());
-
-  const handleCheckboxChange = (packageId: string) => {
-    setSelectedPackages((prevSelected) => {
-      const newSelected = new Set(prevSelected);
-      if (newSelected.has(packageId)) {
-        newSelected.delete(packageId);
-      } else {
-        newSelected.add(packageId);
-      }
-      return newSelected;
-    });
-  };
-
-  const handleDelete = () => {
-    selectedPackages.forEach((packageId) => {
-      context?.deleteCommissioningPackage(packageId);
-    });
-    setIsDeleteOpen(false);
-    setSelectedPackages(new Set());
-  };
-
-  useEffect(() => {
-    if (isDeleteOpen && context?.activePackage) {
-      setSelectedPackages(new Set([context.activePackage.id]));
-    }
-  }, [isDeleteOpen, context?.activePackage]);
 
   const menuItemsInitial: SidebarLinkProps[] = [
     {
@@ -69,63 +43,17 @@ export default function EditorSidebar() {
       },
     },
   ];
+
   return (
     <>
       <CommissioningPackageCreationDialog
         open={isCreationOpen}
         setOpen={setIsCreationOpen}
       />
-      <Dialog
-          open={isDeleteOpen}
-          onClose={() => {
-            setIsDeleteOpen(false);
-          }}
-      >
-        <Dialog.Header>
-          <Dialog.Title>
-            Delete Commissioning Packages
-          </Dialog.Title>
-        </Dialog.Header>
-        <Dialog.CustomContent>
-          Choose which commissioning packages to delete:
-          {context?.commissioningPackages.map((commpckg) => (
-              <Table key={commpckg.id}>
-                <Table.Row>
-                  <Table.Cell>
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                      <div
-                          style={{
-                            width: '16px',
-                            height: '16px',
-                            backgroundColor: commpckg.color,
-                            borderRadius: '50%',
-                            marginRight: '8px',
-                          }}
-                      ></div>
-                      <Checkbox
-                          label={commpckg.name}
-                          name="multiple"
-                          checked={selectedPackages.has(commpckg.id)}
-                          onChange={() => handleCheckboxChange(commpckg.id)}
-                      />
-                    </div>
-                  </Table.Cell>
-                </Table.Row>
-              </Table>
-          ))}
-        </Dialog.CustomContent>
-        <Dialog.Actions>
-          <Button onClick={handleDelete}>
-            Delete
-          </Button>
-          <Button variant="ghost" onClick={() => {
-            setIsDeleteOpen(false);
-          }}
-          >
-            Cancel
-          </Button>
-        </Dialog.Actions>
-      </Dialog>
+      <CommissioningPackageDeletionDialog
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+      />
       <StyledSideBar>
         <SideBar>
           <SideBar.Content>

--- a/www/src/components/editor/EditorSidebar.tsx
+++ b/www/src/components/editor/EditorSidebar.tsx
@@ -1,4 +1,4 @@
-import { SideBar, SidebarLinkProps } from "@equinor/eds-core-react";
+import { Button, Dialog, SideBar, SidebarLinkProps } from "@equinor/eds-core-react";
 import { add, boundaries, category, texture, delete_to_trash } from "@equinor/eds-icons";
 import styled from "styled-components";
 import { useContext, useState } from "react";
@@ -15,6 +15,7 @@ export default function EditorSidebar() {
   const context = useCommissioningPackageContext();
   const { activeTool, setActiveTool } = useContext(ToolContext);
   const [isCreationOpen, setIsCreationOpen] = useState<boolean>(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
 
   const menuItemsInitial: SidebarLinkProps[] = [
     {
@@ -37,7 +38,7 @@ export default function EditorSidebar() {
       label: "Delete commissioning package",
       icon: delete_to_trash,
       onClick: () => {
-        context?.deleteCommissioningPackage(context.activePackage.id);
+        setIsDeleteOpen(true);
       },
     },
   ];
@@ -47,6 +48,38 @@ export default function EditorSidebar() {
         open={isCreationOpen}
         setOpen={setIsCreationOpen}
       />
+      <Dialog
+          open={isDeleteOpen}
+          onClose={() => {
+            setIsDeleteOpen(false);
+          }}
+      >
+        <Dialog.Header>
+          <Dialog.Title>
+            Delete Commissioning Package
+          </Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Content>
+          {`Do you really want to delete commissioning package with id `}
+          <strong>{context?.activePackage.id}</strong>
+          {`?`}
+        </Dialog.Content>
+        <Dialog.Actions>
+          <Button
+              onClick={() => {
+                context?.deleteCommissioningPackage(context.activePackage.id);
+              }}
+          >
+            Delete
+          </Button>
+          <Button variant="ghost" onClick={() => {
+            setIsDeleteOpen(false);
+          }}
+          >
+            Cancel
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
       <StyledSideBar>
         <SideBar>
           <SideBar.Content>

--- a/www/src/components/editor/EditorSidebar.tsx
+++ b/www/src/components/editor/EditorSidebar.tsx
@@ -68,6 +68,7 @@ export default function EditorSidebar() {
           <Button
               onClick={() => {
                 context?.deleteCommissioningPackage(context.activePackage.id);
+                setIsDeleteOpen(false);
               }}
           >
             Delete

--- a/www/src/components/editor/EditorSidebar.tsx
+++ b/www/src/components/editor/EditorSidebar.tsx
@@ -1,7 +1,7 @@
 import {Button, Checkbox, Dialog, SideBar, SidebarLinkProps, Table} from "@equinor/eds-core-react";
 import { add, boundaries, category, texture, delete_to_trash } from "@equinor/eds-icons";
 import styled from "styled-components";
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import Tools from "../../enums/Tools.ts";
 import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 import ToolContext from "../../context/ToolContext.ts";
@@ -37,6 +37,12 @@ export default function EditorSidebar() {
     setIsDeleteOpen(false);
     setSelectedPackages(new Set());
   };
+
+  useEffect(() => {
+    if (isDeleteOpen && context?.activePackage) {
+      setSelectedPackages(new Set([context.activePackage.id]));
+    }
+  }, [isDeleteOpen, context?.activePackage]);
 
   const menuItemsInitial: SidebarLinkProps[] = [
     {

--- a/www/src/components/editor/EditorSidebar.tsx
+++ b/www/src/components/editor/EditorSidebar.tsx
@@ -1,5 +1,5 @@
 import { SideBar, SidebarLinkProps } from "@equinor/eds-core-react";
-import { add, boundaries, category, texture } from "@equinor/eds-icons";
+import { add, boundaries, category, texture, delete_to_trash } from "@equinor/eds-icons";
 import styled from "styled-components";
 import { useContext, useState } from "react";
 import Tools from "../../enums/Tools.ts";
@@ -32,6 +32,13 @@ export default function EditorSidebar() {
         setActiveTool(Tools.INSIDEBOUNDARY);
       },
       active: activeTool === Tools.INSIDEBOUNDARY,
+    },
+    {
+      label: "Delete commissioning package",
+      icon: delete_to_trash,
+      onClick: () => {
+        context?.deleteCommissioningPackage(context.activePackage.id);
+      },
     },
   ];
   return (

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -38,7 +38,12 @@ export const CommissioningPackageContextProvider: React.FC<{
   }, [activePackage, commissioningPackages]);
 
   const deleteCommissioningPackage = (packageId: string) => {
-    console.log("Deleting package with id: ", packageId);
+    setCommissioningPackages((prevPackages) =>
+      prevPackages.filter((pkg) => pkg.id !== packageId)
+    );
+    if (activePackage.id === packageId) {
+      setActivePackage(commissioningPackages[0]);
+    }
   };
 
   return (

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -9,6 +9,7 @@ export interface CommissioningPackageContextProps {
   setCommissioningPackages: React.Dispatch<
     React.SetStateAction<CommissioningPackage[]>
   >;
+  deleteCommissioningPackage: (packageId: string) => void;
 }
 
 const CommissioningPackageContext = createContext<
@@ -36,6 +37,10 @@ export const CommissioningPackageContextProvider: React.FC<{
     }
   }, [activePackage, commissioningPackages]);
 
+  const deleteCommissioningPackage = (packageId: string) => {
+    console.log("Deleting package with id: ", packageId);
+  };
+
   return (
     <CommissioningPackageContext.Provider
       value={{
@@ -43,6 +48,7 @@ export const CommissioningPackageContextProvider: React.FC<{
         setActivePackage,
         commissioningPackages,
         setCommissioningPackages,
+        deleteCommissioningPackage,
       }}
     >
       {children}

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useEffect, useState } from "react";
 import CommissioningPackage from "../types/CommissioningPackage.ts";
 import HighlightColors from "../enums/HighlightColors.ts";
+import { deletePackageFromTripleStore } from "../utils/Triplestore.ts";
 
 export interface CommissioningPackageContextProps {
   activePackage: CommissioningPackage;
@@ -37,8 +38,10 @@ export const CommissioningPackageContextProvider: React.FC<{
     }
   }, [activePackage, commissioningPackages]);
 
-  const deleteCommissioningPackage = (packageId: string) => {
-    if (commissioningPackages.length === 1) {
+  const deleteCommissioningPackage = async (packageId: string) => {
+      await deletePackageFromTripleStore(packageId);
+
+      if (commissioningPackages.length === 1) {
       const initialPackage = createInitialPackage();
       setCommissioningPackages([initialPackage]);
       setActivePackage(initialPackage);

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -11,13 +11,14 @@ export interface CommissioningPackageContextProps {
     React.SetStateAction<CommissioningPackage[]>
   >;
   deleteCommissioningPackage: (packageId: string) => void;
+  createInitialPackage: () => CommissioningPackage;
 }
 
 const CommissioningPackageContext = createContext<
   CommissioningPackageContextProps | undefined
 >(undefined);
 
-const createInitialPackage = (): CommissioningPackage => ({
+export const createInitialPackage = (): CommissioningPackage => ({
   id: "asset:Package1",
   name: "Initial Package",
   color: HighlightColors.LASER_LEMON,
@@ -82,6 +83,7 @@ export const CommissioningPackageContextProvider: React.FC<{
         commissioningPackages,
         setCommissioningPackages,
         deleteCommissioningPackage,
+        createInitialPackage,
       }}
     >
       {children}

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -16,20 +16,20 @@ const CommissioningPackageContext = createContext<
   CommissioningPackageContextProps | undefined
 >(undefined);
 
+const createInitialPackage = (): CommissioningPackage => ({
+  id: "asset:Package1",
+  name: "Initial Package",
+  color: HighlightColors.LASER_LEMON,
+  boundaryIds: [],
+  internalIds: [],
+  nodeIds: [],
+});
+
 export const CommissioningPackageContextProvider: React.FC<{
   children: React.ReactNode;
 }> = ({ children }) => {
-  const [activePackage, setActivePackage] = useState<CommissioningPackage>({
-    id: "asset:Package1",
-    name: "Initial Package",
-    color: HighlightColors.LASER_LEMON,
-    boundaryIds: [],
-    internalIds: [],
-    nodeIds: [],
-  });
-  const [commissioningPackages, setCommissioningPackages] = useState<
-    CommissioningPackage[]
-  >([]);
+  const [activePackage, setActivePackage] = useState<CommissioningPackage>(createInitialPackage());
+  const [commissioningPackages, setCommissioningPackages] = useState<CommissioningPackage[]>([]);
 
   useEffect(() => {
     if (activePackage && commissioningPackages.length === 0) {
@@ -38,11 +38,36 @@ export const CommissioningPackageContextProvider: React.FC<{
   }, [activePackage, commissioningPackages]);
 
   const deleteCommissioningPackage = (packageId: string) => {
+    if (commissioningPackages.length === 1) {
+      const initialPackage = createInitialPackage();
+      setCommissioningPackages([initialPackage]);
+      setActivePackage(initialPackage);
+    } else {
+      setCommissioningPackages((prevPackages) => {
+        const updatedPackages = prevPackages.filter((pkg) => pkg.id !== packageId);
+        if (activePackage.id === packageId) {
+          setActivePackage(updatedPackages[0]);
+        }
+        return updatedPackages;
+      });
+    }
+
     setCommissioningPackages((prevPackages) =>
-      prevPackages.filter((pkg) => pkg.id !== packageId)
+      prevPackages.map((pkg) => ({
+          ...pkg,
+          boundaryIds: pkg.boundaryIds.filter((id) => id !== packageId),
+          internalIds: pkg.internalIds.filter((id) => id !== packageId),
+          nodeIds: pkg.nodeIds.filter((id) => id !== packageId),
+      }))
     );
+
     if (activePackage.id === packageId) {
-      setActivePackage(commissioningPackages[0]);
+      setActivePackage((prevPackage) => ({
+          ...prevPackage,
+          boundaryIds: [],
+          internalIds: [],
+          nodeIds: [],
+      }));
     }
   };
 

--- a/www/src/utils/Triplestore.ts
+++ b/www/src/utils/Triplestore.ts
@@ -30,6 +30,13 @@ export async function cleanTripleStore() {
   await queryTripleStore(deleteInternal, Method.Post);
 }
 
+export async function deletePackageFromTripleStore(packageId: string) {
+  const deleteBoundary = "DELETE WHERE { ?boundary comp:isBoundaryOf " + packageId + " . }";
+  const deleteInternal = "DELETE WHERE { ?internal comp:isInPackage " + packageId + " . }";
+  await queryTripleStore(deleteBoundary, Method.Post);
+  await queryTripleStore(deleteInternal, Method.Post);
+}
+
 export async function getNodeIdsInCommissioningPackage(packageIri: string) {
   const query =
     "SELECT ?node WHERE{?node comp:isInPackage " + packageIri + " .}";


### PR DESCRIPTION
[Pull requests practices for the SSI team](https://github.com/equinor/ssi-infrastructure/blob/main/docs/pr_practices.md)

## Aim of the PR
This PR fixes [AB#208957](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/208957).

The goal of this PR is to add functionality for deleting commissioning packages. 

## Implementation 
I added a new sidebar item with a delete icon. When the user clicks the button, a dialog opens. The dialog shows all commissioning packages, and the user must choose which packages they want to delete. The active package will be automatically checked, as it is likely the user wants to delete the package that is currently active. When you delete the last commissioning package, a new initial commissioning package will be created. 

## Type of change
- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

## How Has This Been Tested?
This has been tested by running the demo and seeing that it is possible to delete commissioning packages. See screenshots:
![image](https://github.com/user-attachments/assets/499cbf20-ba0c-4ff3-90f8-90670b169395)
![image](https://github.com/user-attachments/assets/0b9af7d5-14a8-4944-bf5a-953bb36be40a)
![image](https://github.com/user-attachments/assets/488464d0-4bb8-446c-8142-6def75d0aefa)

