### PR TITLE
Story 208659: Zoom functionality added

### DIFF
--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@equinor/eds-core-react": "^0.42.5",
         "@svgr/core": "^8.1.0",
+        "@types/react-svg-pan-zoom": "^3.3.9",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-svg-pan-zoom": "^3.13.1",
         "styled-components": "^6.1.13",
         "xml-to-react": "^1.2.2"
       },
@@ -4909,14 +4911,12 @@
       "version": "15.7.13",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4928,6 +4928,15 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-svg-pan-zoom": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@types/react-svg-pan-zoom/-/react-svg-pan-zoom-3.3.9.tgz",
+      "integrity": "sha512-/VA3nI3OmIjgrvWPPeesyON2OxoC27v4yuZ2VRjItXrQnmGZTnQb2WUafLm7+weTUsfFfmngGAyH8oIlbKDkNA==",
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -7013,6 +7022,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-svg-pan-zoom": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/react-svg-pan-zoom/-/react-svg-pan-zoom-3.13.1.tgz",
+      "integrity": "sha512-mUGoXfo255c+T/FAdZ5Fr0paw9OpAz4owGku5bRjUOzSKUmqUJpuYbscuuzOIJWbmrJ0N/9mOWPE8JdjSYITbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "transformation-matrix": "^2.16.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/chrvadala"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -7389,6 +7411,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/transformation-matrix": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-2.16.1.tgz",
+      "integrity": "sha512-tdtC3wxVEuzU7X/ydL131Q3JU5cPMEn37oqVLITjRDSDsnSHVFzW2JiCLfZLIQEgWzZHdSy3J6bZzvKEN24jGA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/chrvadala"
       }
     },
     "node_modules/ts-api-utils": {

--- a/www/package.json
+++ b/www/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@equinor/eds-core-react": "^0.42.5",
     "@svgr/core": "^8.1.0",
+    "@types/react-svg-pan-zoom": "^3.3.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-svg-pan-zoom": "^3.13.1",
     "styled-components": "^6.1.13",
     "xml-to-react": "^1.2.2"
   },

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -1,6 +1,6 @@
 import { XMLParser } from "fast-xml-parser";
 import Equipment from "./Equipment.tsx";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ProcessInstrumentationFunction from "./ProcessInstrumentationFunction.tsx";
 import { EquipmentProps, XMLProps } from "../../types/diagram/Diagram.ts";
 import { PipingNetworkSystemProps } from "../../types/diagram/Piping.ts";
@@ -13,6 +13,7 @@ import { cleanTripleStore } from "../../utils/Triplestore.ts";
 import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 import styled from "styled-components";
 import { preloadSVGs } from "../../utils/SvgEdit.ts";
+import ZoomableSVGWrapper from "../editor/ZoomableSVGWrapper.tsx";
 
 const SVGContainer = styled.div`
   width: 100%;
@@ -33,6 +34,7 @@ export default function Pandid() {
     ActuatingSystemProps[]
   >([]);
   const [svgMap, setSvgMap] = useState<Map<string, Element | null>>(new Map());
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const parser = new XMLParser({
     ignoreAttributes: false,
@@ -72,55 +74,63 @@ export default function Pandid() {
       const preloadedMap = await preloadSVGs(xmlData);
       setSvgMap(preloadedMap);
     };
-
     initializeSvgMap();
   }, [xmlData]);
 
   return (
-    <SVGContainer>
+    <SVGContainer ref={containerRef}>
       {xmlData && (
         <PandidContext.Provider
           value={{
-            height: xmlData.PlantModel.Drawing.Extent.Max.Y,
+            height: parseInt(xmlData.PlantModel.Drawing.Extent.Max.Y),
             svgMap,
             setSvgMap,
           }}
         >
-          <svg
-            viewBox={`${xmlData.PlantModel.Drawing.Extent.Min.X} ${xmlData.PlantModel.Drawing.Extent.Min.Y} ${xmlData.PlantModel.Drawing.Extent.Max.X} ${xmlData.PlantModel.Drawing.Extent.Max.Y}`}
-            width={"100%"}
-            height={"100%"}
+          {" "}
+          <ZoomableSVGWrapper
+            containerRef={containerRef}
+            svgWidth={parseInt(String(xmlData.PlantModel.Drawing.Extent.Max.X))}
+            svgHeight={parseInt(
+              String(xmlData.PlantModel.Drawing.Extent.Max.Y),
+            )}
           >
-            {equipments &&
-              equipments.map((equipment: EquipmentProps, index: number) => (
-                <Equipment key={index} {...equipment} />
-              ))}
-            {pipingNetworkSystems &&
-              pipingNetworkSystems.map(
-                (
-                  pipingNetworkSystem: PipingNetworkSystemProps,
-                  index: number,
-                ) => <PipeSystem key={index} {...pipingNetworkSystem} />,
-              )}
-            {processInstrumentationFunction &&
-              processInstrumentationFunction.map(
-                (
-                  processInstrumentationFunction: ProcessInstrumentationFunctionProps,
-                  index: number,
-                ) => (
-                  <ProcessInstrumentationFunction
-                    key={index}
-                    {...processInstrumentationFunction}
-                  />
-                ),
-              )}
-            {actuatingSystem &&
-              actuatingSystem.map(
-                (actuatingSystem: ActuatingSystemProps, index: number) => (
-                  <ActuatingSystem key={index} {...actuatingSystem} />
-                ),
-              )}
-          </svg>
+            <svg
+              viewBox={`${xmlData.PlantModel.Drawing.Extent.Min.X} ${xmlData.PlantModel.Drawing.Extent.Min.Y} ${xmlData.PlantModel.Drawing.Extent.Max.X} ${xmlData.PlantModel.Drawing.Extent.Max.Y}`}
+              width={"100%"}
+              height={"100%"}
+            >
+              {equipments &&
+                equipments.map((equipment: EquipmentProps, index: number) => (
+                  <Equipment key={index} {...equipment} />
+                ))}
+              {pipingNetworkSystems &&
+                pipingNetworkSystems.map(
+                  (
+                    pipingNetworkSystem: PipingNetworkSystemProps,
+                    index: number,
+                  ) => <PipeSystem key={index} {...pipingNetworkSystem} />,
+                )}
+              {processInstrumentationFunction &&
+                processInstrumentationFunction.map(
+                  (
+                    processInstrumentationFunction: ProcessInstrumentationFunctionProps,
+                    index: number,
+                  ) => (
+                    <ProcessInstrumentationFunction
+                      key={index}
+                      {...processInstrumentationFunction}
+                    />
+                  ),
+                )}
+              {actuatingSystem &&
+                actuatingSystem.map(
+                  (actuatingSystem: ActuatingSystemProps, index: number) => (
+                    <ActuatingSystem key={index} {...actuatingSystem} />
+                  ),
+                )}
+            </svg>
+          </ZoomableSVGWrapper>
         </PandidContext.Provider>
       )}
     </SVGContainer>

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -88,13 +88,7 @@ export default function Pandid() {
           }}
         >
           {" "}
-          <ZoomableSVGWrapper
-            containerRef={containerRef}
-            svgWidth={parseInt(String(xmlData.PlantModel.Drawing.Extent.Max.X))}
-            svgHeight={parseInt(
-              String(xmlData.PlantModel.Drawing.Extent.Max.Y),
-            )}
-          >
+          <ZoomableSVGWrapper containerRef={containerRef}>
             <svg
               viewBox={`${xmlData.PlantModel.Drawing.Extent.Min.X} ${xmlData.PlantModel.Drawing.Extent.Min.Y} ${xmlData.PlantModel.Drawing.Extent.Max.X} ${xmlData.PlantModel.Drawing.Extent.Max.Y}`}
               width={"100%"}

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -82,7 +82,7 @@ export default function Pandid() {
       {xmlData && (
         <PandidContext.Provider
           value={{
-            height: parseInt(xmlData.PlantModel.Drawing.Extent.Max.Y),
+            height: Number(xmlData.PlantModel.Drawing.Extent.Max.Y),
             svgMap,
             setSvgMap,
           }}

--- a/www/src/components/editor/ZoomableSVGWrapper.tsx
+++ b/www/src/components/editor/ZoomableSVGWrapper.tsx
@@ -1,0 +1,65 @@
+import { TOOL_AUTO, UncontrolledReactSVGPanZoom } from "react-svg-pan-zoom";
+import { ReactElement, RefObject, useEffect, useRef, useState } from "react";
+
+interface ZoomableSVGWrapperProps {
+  containerRef: RefObject<HTMLDivElement>;
+  svgWidth: number;
+  svgHeight: number;
+  children: ReactElement;
+}
+
+export default function ZoomableSVGWrapper({
+  containerRef,
+  children,
+}: ZoomableSVGWrapperProps) {
+  const Viewer = useRef<UncontrolledReactSVGPanZoom>(null);
+  const [dimensions, setDimensions] = useState({
+    width: 0,
+    height: 0,
+  });
+
+  // Dynamically update dimensions on mount and resize
+  useEffect(() => {
+    const updateDimensions = () => {
+      if (containerRef.current) {
+        setDimensions({
+          width: containerRef.current.offsetWidth,
+          height: containerRef.current.offsetHeight,
+        });
+      }
+    };
+
+    updateDimensions();
+    window.addEventListener("resize", updateDimensions);
+    return () => window.removeEventListener("resize", updateDimensions);
+  }, []);
+
+  // Fit SVG to screen on mount
+  useEffect(() => {
+    if (Viewer.current) {
+      Viewer.current.fitToViewer();
+    }
+  }, [dimensions]);
+
+  return (
+    <>
+      {dimensions.width > 0 && dimensions.height > 0 && (
+        <UncontrolledReactSVGPanZoom
+          width={dimensions.width}
+          height={dimensions.height}
+          background={"#FFFFFF"}
+          scaleFactorMin={2}
+          scaleFactorMax={10}
+          tool={TOOL_AUTO}
+          ref={Viewer}
+          detectAutoPan={false}
+          onChangeValue={() => {}}
+          onChangeTool={() => {}}
+          detectWheel={true}
+        >
+          {children}
+        </UncontrolledReactSVGPanZoom>
+      )}
+    </>
+  );
+}

--- a/www/src/components/editor/ZoomableSVGWrapper.tsx
+++ b/www/src/components/editor/ZoomableSVGWrapper.tsx
@@ -3,8 +3,6 @@ import { ReactElement, RefObject, useEffect, useRef, useState } from "react";
 
 interface ZoomableSVGWrapperProps {
   containerRef: RefObject<HTMLDivElement>;
-  svgWidth: number;
-  svgHeight: number;
   children: ReactElement;
 }
 

--- a/www/src/types/diagram/Drawing.ts
+++ b/www/src/types/diagram/Drawing.ts
@@ -11,8 +11,8 @@ export interface DrawingProps {
 export type PresentationProps = object;
 
 export interface XYProps {
-  X: number;
-  Y: number;
+  X: string;
+  Y: string;
 }
 
 export interface ExtentProps {


### PR DESCRIPTION
## Aim of the PR
This PR fixes [AB#208659](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/208659)

This PR aims to complete the sprint goal of adding zoom functionality to the frontend.

## Implementation 
Added the package react-svg-zoom-pan.
Created a new component, ZoomableSVGWrapper, which sets up the UncontrolledReactSVGZoomPan component and initializes some values.

It should now be possible to zoom by pinching or using the scroll wheel, and pan by left clicking and dragging the SVG.

The toolbar can be overrided with a custom toolbar, might be nice to implement it on the side with the other tools. :)

## Type of change
- [X] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

If the changes impact any dependent services then provide details.
## How Has This Been Tested?
Tested by using touchpad to pinch zoom, and clicking and dragging to pan. Not tested with mouse and scroll wheel.

## Additional Changes
The Drawing.Extent values are always of type string in the XML, but they are parsed as numbers, which does not work in typescript. I have updated the types to be of type string, and then we need to cast the values to numbers.