### PR TITLE
Persist commissioning packages on refresh

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     working_dir: /app/local/www
     environment:
       - NODE_ENV=development
+      - WATCHPACK_POLLING=true
     ports:
       - 8081:8081
     volumes:

--- a/www/src/App.css
+++ b/www/src/App.css
@@ -19,7 +19,7 @@ body,
     }
 }
 
-.internal {
+.selectedInternal {
     path {
         stroke: green;
     }

--- a/www/src/components/diagram/CenterLine.tsx
+++ b/www/src/components/diagram/CenterLine.tsx
@@ -22,12 +22,16 @@ export default function CenterLine(props: CenterLineComponentProps) {
   const tool = useContext(ToolContext).activeTool;
   let color: HighlightColors | undefined;
   let iri: string;
+  let hasBoundaryNode: boolean;
+  let hasSelectedInternalNode: boolean;
   if (props.id) {
     iri = iriFromSvgNode(props.id);
     const commissioningPackage = context.commissioningPackages.find((pkg) =>
       pkg.boundaryIds.includes(iri) || pkg.internalIds.includes(iri),
     );
     color = commissioningPackage?.color;
+    hasBoundaryNode = context.activePackage.boundaryIds.length > 0;
+    hasSelectedInternalNode = context.activePackage.selectedInternalIds.length > 0;
   }
 
   return (
@@ -35,7 +39,7 @@ export default function CenterLine(props: CenterLineComponentProps) {
       {props.centerLines.map((centerline: CenterLineProps, index: number) =>
         centerline !== undefined ? (
           <React.Fragment key={index}>
-            {color && (
+            {color && hasBoundaryNode && hasSelectedInternalNode && (
               <path
                 id={iri ? iri : props.id}
                 key={index + "_highlight"}

--- a/www/src/components/diagram/CenterLine.tsx
+++ b/www/src/components/diagram/CenterLine.tsx
@@ -25,7 +25,7 @@ export default function CenterLine(props: CenterLineComponentProps) {
   if (props.id) {
     iri = iriFromSvgNode(props.id);
     const commissioningPackage = context.commissioningPackages.find((pkg) =>
-      pkg.nodeIds.find((node) => node === iri),
+      pkg.boundaryIds.includes(iri) || pkg.internalIds.includes(iri),
     );
     color = commissioningPackage?.color;
   }

--- a/www/src/components/diagram/CenterLine.tsx
+++ b/www/src/components/diagram/CenterLine.tsx
@@ -47,7 +47,7 @@ export default function CenterLine(props: CenterLineComponentProps) {
             )}
             <StyledPath
               onClick={() =>
-                props.id ? selectHandleFunction(props.id, context, tool) : {}
+                iri ? selectHandleFunction(iri, context, tool) : {}
               }
               key={index}
               d={constructPath(centerline.Coordinate, height)}

--- a/www/src/components/diagram/CenterLine.tsx
+++ b/www/src/components/diagram/CenterLine.tsx
@@ -22,7 +22,6 @@ export default function CenterLine(props: CenterLineComponentProps) {
   const tool = useContext(ToolContext).activeTool;
   let color: HighlightColors | undefined;
   let iri: string;
-  let hasBoundaryNode: boolean;
   let hasSelectedInternalNode: boolean;
   if (props.id) {
     iri = iriFromSvgNode(props.id);
@@ -30,8 +29,8 @@ export default function CenterLine(props: CenterLineComponentProps) {
       pkg.boundaryIds.includes(iri) || pkg.internalIds.includes(iri),
     );
     color = commissioningPackage?.color;
-    hasBoundaryNode = context.activePackage.boundaryIds.length > 0;
-    hasSelectedInternalNode = context.activePackage.selectedInternalIds.length > 0;
+    if (commissioningPackage)
+      hasSelectedInternalNode = commissioningPackage.selectedInternalIds.length > 0;
   }
 
   return (
@@ -39,7 +38,7 @@ export default function CenterLine(props: CenterLineComponentProps) {
       {props.centerLines.map((centerline: CenterLineProps, index: number) =>
         centerline !== undefined ? (
           <React.Fragment key={index}>
-            {color && hasBoundaryNode && hasSelectedInternalNode && (
+            {color && hasSelectedInternalNode && (
               <path
                 id={iri ? iri : props.id}
                 key={index + "_highlight"}

--- a/www/src/components/diagram/Equipment.tsx
+++ b/www/src/components/diagram/Equipment.tsx
@@ -44,7 +44,7 @@ export default function Equipment(props: EquipmentProps) {
           <>
             {color && (
               <StyledSvgElement
-                id={iri + "_highlight"}
+                id={iri}
                 position={props.Position}
                 svg={svg}
                 color={color}

--- a/www/src/components/diagram/Equipment.tsx
+++ b/www/src/components/diagram/Equipment.tsx
@@ -37,7 +37,7 @@ export default function Equipment(props: EquipmentProps) {
     <>
       <g
         onClick={() =>
-          isInActivePackage ? selectHandleFunction(props.ID, context, tool) : {}
+          isInActivePackage ? selectHandleFunction(iri, context, tool) : {}
         }
       >
         {svg && (
@@ -53,7 +53,7 @@ export default function Equipment(props: EquipmentProps) {
             <g
               id={iri}
               transform={`${props.Position.Reference.X === -1 ? "rotate(-180deg)" : ""}translate(${props.Position.Location.X}, ${height - props.Position.Location.Y})`}
-              className={`.node ${isBoundary(props.ID, context) ? "boundary" : ""} ${isInternal(props.ID, context) ? "internal" : ""}`}
+              className={`.node ${isBoundary(iri, context) ? "boundary" : ""} ${isInternal(iri, context) ? "internal" : ""}`}
               dangerouslySetInnerHTML={{ __html: svg }}
             />
           </>

--- a/www/src/components/diagram/Equipment.tsx
+++ b/www/src/components/diagram/Equipment.tsx
@@ -8,7 +8,7 @@ import { useCommissioningPackageContext } from "../../hooks/useCommissioningPack
 import {
   iriFromSvgNode,
   isBoundary,
-  isInternal,
+  isSelectedInternal,
 } from "../../utils/HelperFunctions.ts";
 import ToolContext from "../../context/ToolContext.ts";
 import selectHandleFunction from "../../utils/HandlerFunctionHelper.tsx";
@@ -53,7 +53,7 @@ export default function Equipment(props: EquipmentProps) {
             <g
               id={iri}
               transform={`${props.Position.Reference.X === -1 ? "rotate(-180deg)" : ""}translate(${props.Position.Location.X}, ${height - props.Position.Location.Y})`}
-              className={`.node ${isBoundary(iri, context) ? "boundary" : ""} ${isInternal(iri, context) ? "internal" : ""}`}
+              className={`.node ${isBoundary(iri, context) ? "boundary" : ""} ${isSelectedInternal(iri, context) ? "selectedInternal" : ""}`}
               dangerouslySetInnerHTML={{ __html: svg }}
             />
           </>

--- a/www/src/components/diagram/Equipment.tsx
+++ b/www/src/components/diagram/Equipment.tsx
@@ -25,8 +25,8 @@ export default function Equipment(props: EquipmentProps) {
   const nozzles: NozzleProps[] = props.Nozzle;
 
   const iri = iriFromSvgNode(props.ID);
-  const commissioningPackage = context.commissioningPackages.find(
-    (pkg) => pkg.nodeIds.includes(iri) || pkg.boundaryIds.includes(iri),
+  const commissioningPackage = context.commissioningPackages.find((pkg) =>
+    pkg.boundaryIds.includes(iri) || pkg.internalIds.includes(iri),
   );
   const isInActivePackage = commissioningPackage
     ? context.activePackage.id === commissioningPackage.id

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -41,7 +41,7 @@ export default function Pandid() {
     attributeNamePrefix: "",
   });
 
-// Step 1: Fetch existing commissioning packages on initial app load
+// Step 1: Fetch existing commissioning packages
   useEffect(() => {
     (async () => {
       const packages = await getAllCommissioningPackages();

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -9,7 +9,7 @@ import { ActuatingSystemProps } from "../../types/diagram/ActuatingSystem.ts";
 import ActuatingSystem from "./ActuatingSystem.tsx";
 import PandidContext from "../../context/PandidContext.ts";
 import PipeSystem from "./piping/PipeSystem.tsx";
-import { cleanTripleStore } from "../../utils/Triplestore.ts";
+import { getAllCommissioningPackages } from "../../utils/Triplestore.ts";
 import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 import styled from "styled-components";
 import { preloadSVGs } from "../../utils/SvgEdit.ts";
@@ -41,17 +41,12 @@ export default function Pandid() {
     attributeNamePrefix: "",
   });
 
-// Step 1: Clean triplestore on initial app load
+// Step 1: Fetch existing commissioning packages on initial app load
   useEffect(() => {
-    const cleanTripleStoreOnStartup = async () => {
-      const isCleaned = localStorage.getItem("isTripleStoreCleaned");
-      if (!isCleaned) {
-        await cleanTripleStore();
-        context.setCommissioningPackages([]);
-        localStorage.setItem("isTripleStoreCleaned", "true");
-      }
-    };
-    cleanTripleStoreOnStartup();
+    (async () => {
+      const packages = await getAllCommissioningPackages();
+      context.setCommissioningPackages(packages);
+    })();
   }, []);
 
   // Step 2: Read XML file from disk, parse as XMLProps

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -41,12 +41,17 @@ export default function Pandid() {
     attributeNamePrefix: "",
   });
 
-  // Step 1: Clean triplestore on mount
+// Step 1: Clean triplestore on initial app load
   useEffect(() => {
-    (async () => {
-      await cleanTripleStore();
-      context.setCommissioningPackages([]);
-    })();
+    const cleanTripleStoreOnStartup = async () => {
+      const isCleaned = localStorage.getItem("isTripleStoreCleaned");
+      if (!isCleaned) {
+        await cleanTripleStore();
+        context.setCommissioningPackages([]);
+        localStorage.setItem("isTripleStoreCleaned", "true");
+      }
+    };
+    cleanTripleStoreOnStartup();
   }, []);
 
   // Step 2: Read XML file from disk, parse as XMLProps

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -46,6 +46,7 @@ export default function Pandid() {
     (async () => {
       const packages = await getAllCommissioningPackages();
       context.setCommissioningPackages(packages);
+      context.setActivePackage(packages[0]);
     })();
   }, []);
 

--- a/www/src/components/diagram/Pandid.tsx
+++ b/www/src/components/diagram/Pandid.tsx
@@ -46,7 +46,8 @@ export default function Pandid() {
     (async () => {
       const packages = await getAllCommissioningPackages();
       context.setCommissioningPackages(packages);
-      context.setActivePackage(packages[0]);
+      if (packages[0])
+        context.setActivePackage(packages[0]);
     })();
   }, []);
 

--- a/www/src/components/diagram/StyledSvgElement.tsx
+++ b/www/src/components/diagram/StyledSvgElement.tsx
@@ -3,6 +3,7 @@ import calculateAngleAndRotation from "../../utils/Transformation.ts";
 import { useContext } from "react";
 import PandidContext from "../../context/PandidContext.ts";
 import styled from "styled-components";
+import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 
 interface StyledSvgElementProps {
   id: string;
@@ -26,6 +27,13 @@ export default function StyledSvgElement({
   color,
 }: StyledSvgElementProps) {
   const height = useContext(PandidContext).height;
+  const context = useCommissioningPackageContext();
+  const hasBoundaryNode = context.activePackage.boundaryIds.length > 0;
+  const hasSelectedInternalNode = context.activePackage.selectedInternalIds.length > 0;
+
+  if (!hasBoundaryNode || !hasSelectedInternalNode) {
+    return null;
+  }
 
   return (
     <>

--- a/www/src/components/diagram/StyledSvgElement.tsx
+++ b/www/src/components/diagram/StyledSvgElement.tsx
@@ -28,33 +28,36 @@ export default function StyledSvgElement({
 }: StyledSvgElementProps) {
   const height = useContext(PandidContext).height;
   const context = useCommissioningPackageContext();
-  const hasBoundaryNode = context.activePackage.boundaryIds.length > 0;
-  const hasSelectedInternalNode = context.activePackage.selectedInternalIds.length > 0;
+  const commissioningPackage = context.commissioningPackages.find((pkg) =>
+    pkg.boundaryIds.includes(id) || pkg.internalIds.includes(id),
+  );
+  let hasSelectedInternalNode: boolean;
+  if (commissioningPackage) {
+    hasSelectedInternalNode = commissioningPackage.selectedInternalIds.length > 0;
 
-  if (!hasBoundaryNode || !hasSelectedInternalNode) {
-    return null;
-  }
-
-  return (
-    <>
-      {svg && (
-        <StyledG
-          id={id}
-          color={color}
-          transform={
-            position
-              ? calculateAngleAndRotation(
+    return (
+      <>
+        {svg && hasSelectedInternalNode && (
+          <StyledG
+            id={id}
+            color={color}
+            transform={
+              position
+                ? calculateAngleAndRotation(
                   position.Reference.X,
                   position.Reference.Y,
                   position.Location.X,
                   height - position.Location.Y,
                 )
-              : ""
-          }
-          className={".node"}
-          dangerouslySetInnerHTML={{ __html: svg }}
-        />
-      )}
-    </>
-  );
+                : ""
+            }
+            className={".node"}
+            dangerouslySetInnerHTML={{ __html: svg }}
+          />
+        )}
+      </>
+    );
+  }
+
+  return null;
 }

--- a/www/src/components/diagram/SvgElement.tsx
+++ b/www/src/components/diagram/SvgElement.tsx
@@ -45,7 +45,7 @@ export default function SvgElement({
   });
   const iri = iriFromSvgNode(id);
   const commissioningPackage = context.commissioningPackages.find((pkg) =>
-    pkg.nodeIds.find((node) => node === iri),
+    pkg.boundaryIds.includes(iri) || pkg.internalIds.includes(iri),
   );
   const isInActivePackage = commissioningPackage
     ? context.activePackage.id === commissioningPackage.id

--- a/www/src/components/diagram/SvgElement.tsx
+++ b/www/src/components/diagram/SvgElement.tsx
@@ -66,7 +66,7 @@ export default function SvgElement({
           <g
             id={iri}
             onClick={() =>
-              isInActivePackage ? selectHandleFunction(id, context, tool) : {}
+              isInActivePackage ? selectHandleFunction(iri, context, tool) : {}
             }
             transform={
               position
@@ -78,7 +78,7 @@ export default function SvgElement({
                   )
                 : ""
             }
-            className={`.node ${isBoundary(id, context) ? "boundary" : ""} ${isInternal(id, context) ? "internal" : ""}`}
+            className={`.node ${isBoundary(iri, context) ? "boundary" : ""} ${isInternal(iri, context) ? "internal" : ""}`}
             dangerouslySetInnerHTML={{ __html: svg }}
           />
         </>

--- a/www/src/components/diagram/SvgElement.tsx
+++ b/www/src/components/diagram/SvgElement.tsx
@@ -15,7 +15,7 @@ import ToolContext from "../../context/ToolContext.ts";
 import {
   iriFromSvgNode,
   isBoundary,
-  isInternal,
+  isSelectedInternal,
 } from "../../utils/HelperFunctions.ts";
 
 interface SvgElementProps {
@@ -78,7 +78,7 @@ export default function SvgElement({
                   )
                 : ""
             }
-            className={`.node ${isBoundary(iri, context) ? "boundary" : ""} ${isInternal(iri, context) ? "internal" : ""}`}
+            className={`.node ${isBoundary(iri, context) ? "boundary" : ""} ${isSelectedInternal(iri, context) ? "selectedInternal" : ""}`}
             dangerouslySetInnerHTML={{ __html: svg }}
           />
         </>

--- a/www/src/components/diagram/piping/PipeSystem.tsx
+++ b/www/src/components/diagram/piping/PipeSystem.tsx
@@ -71,7 +71,7 @@ export default function PipeSystem(props: PipingNetworkSystemProps) {
         (pipingNetworkSegment: PipingNetworkSegmentProps, index: number) => (
           <PipeSegment
             key={index}
-            onClick={() => selectHandleFunction(props.ID, context, tool)}
+            onClick={() => selectHandleFunction(iri, context, tool)}
             {...pipingNetworkSegment}
           />
         ),

--- a/www/src/components/diagram/piping/PipingComponent.tsx
+++ b/www/src/components/diagram/piping/PipingComponent.tsx
@@ -28,7 +28,7 @@ export default function PipingComponent(props: PipingComponentProps) {
   return (
     <g
       onClick={() =>
-        isInActivePackage ? selectHandleFunction(props.ID, context, tool) : {}
+        isInActivePackage ? selectHandleFunction(iri, context, tool) : {}
       }
     >
       {componentName && (

--- a/www/src/components/diagram/piping/PipingComponent.tsx
+++ b/www/src/components/diagram/piping/PipingComponent.tsx
@@ -19,7 +19,7 @@ export default function PipingComponent(props: PipingComponentProps) {
 
   const iri = iriFromSvgNode(props.ID);
   const commissioningPackage = context.commissioningPackages.find((pkg) =>
-    pkg.nodeIds.find((node) => node === iri),
+    pkg.boundaryIds.includes(iri) || pkg.internalIds.includes(iri),
   );
   const isInActivePackage = commissioningPackage
     ? context.activePackage.id === commissioningPackage.id

--- a/www/src/components/editor/CommissioningPackageCreationDialog.tsx
+++ b/www/src/components/editor/CommissioningPackageCreationDialog.tsx
@@ -45,7 +45,6 @@ export default function CommissioningPackageCreationDialog(
       color: selectedColor!,
       boundaryIds: [],
       internalIds: [],
-      nodeIds: [],
     };
 
     await addCommissioningPackage(

--- a/www/src/components/editor/CommissioningPackageCreationDialog.tsx
+++ b/www/src/components/editor/CommissioningPackageCreationDialog.tsx
@@ -11,6 +11,7 @@ import React, { useEffect, useState } from "react";
 import CommissioningPackage from "../../types/CommissioningPackage.ts";
 import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 import ColorPreview from "./ColorPreview.tsx";
+import  {makeSparqlAndUpdateStore } from "../../utils/Triplestore.ts";
 
 const ColorSelectionContainer = styled.div`
   display: flex;
@@ -37,15 +38,26 @@ export default function CommissioningPackageCreationDialog(
     HighlightColors | undefined
   >();
 
-  function handleCreate() {
-    setCommissioningPackage({
+  async function handleCreate() {
+    const newPackage = {
       id: "asset:" + id,
       name: name,
       color: selectedColor!,
       boundaryIds: [],
       internalIds: [],
       nodeIds: [],
-    });
+    };
+
+    await makeSparqlAndUpdateStore(
+      newPackage.id,
+      "INSERT DATA",
+      newPackage.name,
+      newPackage.color,
+      null,
+      null,
+    );
+
+    setCommissioningPackage(newPackage);
     props.setOpen(false);
   }
 

--- a/www/src/components/editor/CommissioningPackageCreationDialog.tsx
+++ b/www/src/components/editor/CommissioningPackageCreationDialog.tsx
@@ -11,7 +11,7 @@ import React, { useEffect, useState } from "react";
 import CommissioningPackage from "../../types/CommissioningPackage.ts";
 import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 import ColorPreview from "./ColorPreview.tsx";
-import  {makeSparqlAndUpdateStore } from "../../utils/Triplestore.ts";
+import { addCommissioningPackage } from "../../utils/Triplestore.ts";
 
 const ColorSelectionContainer = styled.div`
   display: flex;
@@ -48,13 +48,10 @@ export default function CommissioningPackageCreationDialog(
       nodeIds: [],
     };
 
-    await makeSparqlAndUpdateStore(
+    await addCommissioningPackage(
       newPackage.id,
-      "INSERT DATA",
       newPackage.name,
       newPackage.color,
-      null,
-      null,
     );
 
     setCommissioningPackage(newPackage);

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -29,7 +29,7 @@ export const createInitialPackage = (): CommissioningPackage => ({
 
 export const CommissioningPackageContextProvider: React.FC<{
   children: React.ReactNode;
-}> = ( {children }) => {
+}> = ({children }) => {
   const [activePackage, setActivePackage] = useState<CommissioningPackage>(createInitialPackage());
   const [commissioningPackages, setCommissioningPackages] = useState<CommissioningPackage[]>([]);
 

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -49,24 +49,24 @@ export const CommissioningPackageContextProvider: React.FC<{
   const deleteCommissioningPackage = async (packageId: string) => {
     await deletePackageFromTripleStore(packageId);
 
-    if (commissioningPackages.length === 1) {
-      const initialPackage = createInitialPackage();
-      await addCommissioningPackage(
-        initialPackage.id,
-        initialPackage.name,
-        initialPackage.color,
-      );
-      setCommissioningPackages([initialPackage]);
-      setActivePackage(initialPackage);
-    } else {
-      setCommissioningPackages((prevPackages) => {
-        const updatedPackages = prevPackages.filter((pkg) => pkg.id !== packageId);
+    setCommissioningPackages((prevPackages) => {
+      const updatedPackages = prevPackages.filter((pkg) => pkg.id !== packageId);
+      if (updatedPackages.length === 0) {
+        const initialPackage = createInitialPackage();
+        addCommissioningPackage(
+          initialPackage.id,
+          initialPackage.name,
+          initialPackage.color,
+        );
+        setActivePackage(initialPackage);
+        return [initialPackage];
+      } else {
         if (activePackage.id === packageId) {
           setActivePackage(updatedPackages[0]);
         }
         return updatedPackages;
-      });
-    }
+      }
+    });
 
     setCommissioningPackages((prevPackages) =>
       prevPackages.map((pkg) => ({

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -24,7 +24,6 @@ export const createInitialPackage = (): CommissioningPackage => ({
   color: HighlightColors.LASER_LEMON,
   boundaryIds: [],
   internalIds: [],
-  nodeIds: [],
 });
 
 export const CommissioningPackageContextProvider: React.FC<{
@@ -73,7 +72,6 @@ export const CommissioningPackageContextProvider: React.FC<{
         ...pkg,
         boundaryIds: pkg.boundaryIds.filter((id) => id !== packageId),
         internalIds: pkg.internalIds.filter((id) => id !== packageId),
-        nodeIds: pkg.nodeIds.filter((id) => id !== packageId),
       }))
     );
 
@@ -82,7 +80,6 @@ export const CommissioningPackageContextProvider: React.FC<{
         ...prevPackage,
         boundaryIds: [],
         internalIds: [],
-        nodeIds: [],
       }));
     }
   };

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useEffect, useState } from "react";
 import CommissioningPackage from "../types/CommissioningPackage.ts";
 import HighlightColors from "../enums/HighlightColors.ts";
-import {deletePackageFromTripleStore, makeSparqlAndUpdateStore} from "../utils/Triplestore.ts";
+import { deletePackageFromTripleStore, addCommissioningPackage } from "../utils/Triplestore.ts";
 
 export interface CommissioningPackageContextProps {
   activePackage: CommissioningPackage;
@@ -37,13 +37,10 @@ export const CommissioningPackageContextProvider: React.FC<{
     if (activePackage && commissioningPackages.length === 0) {
       setCommissioningPackages([activePackage]);
       (async () => {
-        await makeSparqlAndUpdateStore(
+        await addCommissioningPackage(
           activePackage.id,
-          "INSERT DATA",
           activePackage.name,
           activePackage.color,
-          null,
-          null,
         );
       })();
     }
@@ -54,13 +51,10 @@ export const CommissioningPackageContextProvider: React.FC<{
 
     if (commissioningPackages.length === 1) {
       const initialPackage = createInitialPackage();
-      await makeSparqlAndUpdateStore(
+      await addCommissioningPackage(
         initialPackage.id,
-        "INSERT DATA",
         initialPackage.name,
         initialPackage.color,
-        null,
-        null,
       );
       setCommissioningPackages([initialPackage]);
       setActivePackage(initialPackage);

--- a/www/src/context/CommissioningPackageContext.tsx
+++ b/www/src/context/CommissioningPackageContext.tsx
@@ -24,6 +24,7 @@ export const createInitialPackage = (): CommissioningPackage => ({
   color: HighlightColors.LASER_LEMON,
   boundaryIds: [],
   internalIds: [],
+  selectedInternalIds: [],
 });
 
 export const CommissioningPackageContextProvider: React.FC<{

--- a/www/src/types/CommissioningPackage.ts
+++ b/www/src/types/CommissioningPackage.ts
@@ -6,5 +6,4 @@ export default interface CommissioningPackage {
   color: HighlightColors;
   boundaryIds: string[];
   internalIds: string[];
-  nodeIds: string[];
 }

--- a/www/src/types/CommissioningPackage.ts
+++ b/www/src/types/CommissioningPackage.ts
@@ -6,4 +6,5 @@ export default interface CommissioningPackage {
   color: HighlightColors;
   boundaryIds: string[];
   internalIds: string[];
+  selectedInternalIds: string[];
 }

--- a/www/src/utils/HandlerFunctionHelper.tsx
+++ b/www/src/utils/HandlerFunctionHelper.tsx
@@ -1,7 +1,7 @@
 import {
   BoundaryActions,
   BoundaryParts,
-  getNodeIdsInCommissioningPackage,
+  getCommissioningPackage,
   makeSparqlAndUpdateStore,
 } from "./Triplestore.ts";
 import Tools from "../enums/Tools.ts";
@@ -65,11 +65,11 @@ export async function handleAddInternal(
     );
   }
   // Then, update the nodes in package
-  const nodeIds = await getNodeIdsInCommissioningPackage(
+  const commissioningPackage = await getCommissioningPackage(
     context.activePackage.id,
   );
   context.setActivePackage((prev) => {
-    const updatedPackage = { ...prev, nodeIds: nodeIds };
+    const updatedPackage = { ...prev, nodeIds: commissioningPackage.nodeIds, name: commissioningPackage.name, color: commissioningPackage.color};
 
     context.setCommissioningPackages((prevPackages) =>
       prevPackages.map((pkg) =>
@@ -124,11 +124,11 @@ export async function handleAddBoundary(
     );
   }
   // Then, update the nodes in package
-  const nodeIds = await getNodeIdsInCommissioningPackage(
+  const commissioningPackage = await getCommissioningPackage(
     context.activePackage.id,
   );
   context.setActivePackage((prev) => {
-    const updatedPackage = { ...prev, nodeIds: nodeIds };
+    const updatedPackage = { ...prev, nodeIds: commissioningPackage.nodeIds, name: commissioningPackage.name, color: commissioningPackage.color};
 
     context.setCommissioningPackages((prevPackages) =>
       prevPackages.map((pkg) =>

--- a/www/src/utils/HandlerFunctionHelper.tsx
+++ b/www/src/utils/HandlerFunctionHelper.tsx
@@ -31,7 +31,7 @@ export async function handleAddInternal(
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Delete,
-      BoundaryParts.InsideBoundary,
+      BoundaryParts.SelectedInternal,
       context.activePackage.id,
     );
   } else {
@@ -48,7 +48,7 @@ export async function handleAddInternal(
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Insert,
-      BoundaryParts.InsideBoundary,
+      BoundaryParts.SelectedInternal,
       context.activePackage.id,
     );
   }
@@ -61,6 +61,7 @@ export async function handleAddInternal(
       ...prev,
       boundaryIds: commissioningPackage.boundaryIds,
       internalIds: commissioningPackage.internalIds,
+      selectedInternalIds: commissioningPackage.selectedInternalIds,
       name: commissioningPackage.name,
       color: commissioningPackage.color
     };
@@ -94,7 +95,7 @@ export async function handleAddBoundary(
       await makeSparqlAndUpdateStore(
         id,
         BoundaryActions.Delete,
-        BoundaryParts.InsideBoundary,
+        BoundaryParts.SelectedInternal,
         context.activePackage.id,
       );
     }
@@ -114,6 +115,7 @@ export async function handleAddBoundary(
       ...prev,
       boundaryIds: commissioningPackage.boundaryIds,
       internalIds: commissioningPackage.internalIds,
+      selectedInternalIds: commissioningPackage.selectedInternalIds,
       name: commissioningPackage.name,
       color: commissioningPackage.color
     };

--- a/www/src/utils/HandlerFunctionHelper.tsx
+++ b/www/src/utils/HandlerFunctionHelper.tsx
@@ -1,4 +1,5 @@
 import {
+  assetIri,
   BoundaryActions,
   BoundaryParts,
   getCommissioningPackage,
@@ -27,11 +28,7 @@ export async function handleAddInternal(
   context: CommissioningPackageContextProps,
 ) {
   // If element is already inside
-  if (context.activePackage.internalIds.includes(id)) {
-    context.setActivePackage((prev) => ({
-      ...prev,
-      internalIds: prev.internalIds.filter((item) => item !== id),
-    }));
+  if (context.activePackage.internalIds.includes(assetIri(id))) {
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Delete,
@@ -40,11 +37,7 @@ export async function handleAddInternal(
     );
   } else {
     // If the clicked element is a boundary, remove it as a boundary
-    if (context.activePackage.boundaryIds.includes(id)) {
-      context.setActivePackage((prev) => ({
-        ...prev,
-        boundaryIds: prev.boundaryIds.filter((item) => item !== id),
-      }));
+    if (context.activePackage.boundaryIds.includes(assetIri(id))) {
       await makeSparqlAndUpdateStore(
         id,
         BoundaryActions.Delete,
@@ -53,10 +46,6 @@ export async function handleAddInternal(
       );
     }
     // Then, add it as an internal element
-    context.setActivePackage((prev) => ({
-      ...prev,
-      internalIds: prev.internalIds.concat(id),
-    }));
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Insert,
@@ -69,7 +58,13 @@ export async function handleAddInternal(
     context.activePackage.id,
   );
   context.setActivePackage((prev) => {
-    const updatedPackage = { ...prev, nodeIds: commissioningPackage.nodeIds, name: commissioningPackage.name, color: commissioningPackage.color};
+    const updatedPackage = {
+      ...prev,
+      boundaryIds: commissioningPackage.boundaryIds,
+      internalIds: commissioningPackage.internalIds,
+      name: commissioningPackage.name,
+      color: commissioningPackage.color
+    };
 
     context.setCommissioningPackages((prevPackages) =>
       prevPackages.map((pkg) =>
@@ -86,11 +81,7 @@ export async function handleAddBoundary(
   context: CommissioningPackageContextProps,
 ) {
   // If the element is already a boundary, remove it as boundary
-  if (context.activePackage.boundaryIds.includes(id)) {
-    context.setActivePackage((prev) => ({
-      ...prev,
-      boundaryIds: prev.boundaryIds.filter((item) => item !== id),
-    }));
+  if (context.activePackage.boundaryIds.includes(assetIri(id))) {
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Delete,
@@ -100,11 +91,7 @@ export async function handleAddBoundary(
   } else {
     // If element is not already a boundary, add it as boundary.
     // If it is internal, remove it as internal.
-    if (context.activePackage.internalIds.includes(id)) {
-      context.setActivePackage((prev) => ({
-        ...prev,
-        internalIds: prev.internalIds.filter((item) => item !== id),
-      }));
+    if (context.activePackage.internalIds.includes(assetIri(id))) {
       await makeSparqlAndUpdateStore(
         id,
         BoundaryActions.Delete,
@@ -112,10 +99,6 @@ export async function handleAddBoundary(
         context.activePackage.id,
       );
     }
-    context.setActivePackage((prev) => ({
-      ...prev,
-      boundaryIds: prev.boundaryIds.concat(id),
-    }));
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Insert,
@@ -128,7 +111,13 @@ export async function handleAddBoundary(
     context.activePackage.id,
   );
   context.setActivePackage((prev) => {
-    const updatedPackage = { ...prev, nodeIds: commissioningPackage.nodeIds, name: commissioningPackage.name, color: commissioningPackage.color};
+    const updatedPackage = {
+      ...prev,
+      boundaryIds: commissioningPackage.boundaryIds,
+      internalIds: commissioningPackage.internalIds,
+      name: commissioningPackage.name,
+      color: commissioningPackage.color
+    };
 
     context.setCommissioningPackages((prevPackages) =>
       prevPackages.map((pkg) =>

--- a/www/src/utils/HandlerFunctionHelper.tsx
+++ b/www/src/utils/HandlerFunctionHelper.tsx
@@ -1,5 +1,4 @@
 import {
-  assetIri,
   BoundaryActions,
   BoundaryParts,
   getCommissioningPackage,
@@ -28,7 +27,7 @@ export async function handleAddInternal(
   context: CommissioningPackageContextProps,
 ) {
   // If element is already inside
-  if (context.activePackage.internalIds.includes(assetIri(id))) {
+  if (context.activePackage.internalIds.includes(id)) {
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Delete,
@@ -37,7 +36,7 @@ export async function handleAddInternal(
     );
   } else {
     // If the clicked element is a boundary, remove it as a boundary
-    if (context.activePackage.boundaryIds.includes(assetIri(id))) {
+    if (context.activePackage.boundaryIds.includes(id)) {
       await makeSparqlAndUpdateStore(
         id,
         BoundaryActions.Delete,
@@ -81,7 +80,7 @@ export async function handleAddBoundary(
   context: CommissioningPackageContextProps,
 ) {
   // If the element is already a boundary, remove it as boundary
-  if (context.activePackage.boundaryIds.includes(assetIri(id))) {
+  if (context.activePackage.boundaryIds.includes(id)) {
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Delete,
@@ -91,7 +90,7 @@ export async function handleAddBoundary(
   } else {
     // If element is not already a boundary, add it as boundary.
     // If it is internal, remove it as internal.
-    if (context.activePackage.internalIds.includes(assetIri(id))) {
+    if (context.activePackage.internalIds.includes(id)) {
       await makeSparqlAndUpdateStore(
         id,
         BoundaryActions.Delete,

--- a/www/src/utils/HandlerFunctionHelper.tsx
+++ b/www/src/utils/HandlerFunctionHelper.tsx
@@ -31,8 +31,9 @@ export async function handleAddInternal(
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Delete,
-      BoundaryParts.SelectedInternal,
+      BoundaryParts.InsideBoundary,
       context.activePackage.id,
+      true
     );
   } else {
     // If the clicked element is a boundary, remove it as a boundary
@@ -48,8 +49,9 @@ export async function handleAddInternal(
     await makeSparqlAndUpdateStore(
       id,
       BoundaryActions.Insert,
-      BoundaryParts.SelectedInternal,
+      BoundaryParts.InsideBoundary,
       context.activePackage.id,
+      true
     );
   }
   // Then, update the nodes in package
@@ -95,8 +97,9 @@ export async function handleAddBoundary(
       await makeSparqlAndUpdateStore(
         id,
         BoundaryActions.Delete,
-        BoundaryParts.SelectedInternal,
+        BoundaryParts.InsideBoundary,
         context.activePackage.id,
+        true
       );
     }
     await makeSparqlAndUpdateStore(

--- a/www/src/utils/HelperFunctions.ts
+++ b/www/src/utils/HelperFunctions.ts
@@ -5,14 +5,22 @@ export function ensureArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
-export const isBoundary = (
+export function isBoundary (
   id: string,
   context: CommissioningPackageContextProps,
-) => context.activePackage.boundaryIds.includes(id);
-export const isInternal = (
+)
+{
+  console.log("boundaries ", context.activePackage.boundaryIds);
+  console.log("id ", id);
+  console.log("includes boundary ", context.activePackage.boundaryIds.includes(id));
+  return context.activePackage.boundaryIds.includes(id);
+}
+export function isInternal (
   id: string,
   context: CommissioningPackageContextProps,
-) => context.activePackage.internalIds.includes(id);
+) {
+  return context.activePackage.internalIds.includes(id);
+}
 
 export function iriFromSvgNode(id: string) {
   return `https://assetid.equinor.com/plantx#${id}`;

--- a/www/src/utils/HelperFunctions.ts
+++ b/www/src/utils/HelperFunctions.ts
@@ -5,22 +5,18 @@ export function ensureArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value];
 }
 
-export function isBoundary (
+export const isBoundary = (
   id: string,
   context: CommissioningPackageContextProps,
-)
-{
-  console.log("boundaries ", context.activePackage.boundaryIds);
-  console.log("id ", id);
-  console.log("includes boundary ", context.activePackage.boundaryIds.includes(id));
-  return context.activePackage.boundaryIds.includes(id);
-}
-export function isInternal (
+) => context.activePackage.boundaryIds.includes(id);
+export const isInternal = (
   id: string,
   context: CommissioningPackageContextProps,
-) {
-  return context.activePackage.internalIds.includes(id);
-}
+) => context.activePackage.internalIds.includes(id);
+export const isSelectedInternal = (
+  id: string,
+  context: CommissioningPackageContextProps,
+) => context.activePackage.selectedInternalIds?.includes(id);
 
 export function iriFromSvgNode(id: string) {
   return `https://assetid.equinor.com/plantx#${id}`;

--- a/www/src/utils/HelperFunctions.ts
+++ b/www/src/utils/HelperFunctions.ts
@@ -1,5 +1,4 @@
 import { CommissioningPackageContextProps } from "../context/CommissioningPackageContext.tsx";
-import { assetIri } from "./Triplestore.ts";
 import { PipingNetworkSegmentProps } from "../types/diagram/Piping.ts";
 
 export function ensureArray<T>(value: T | T[]): T[] {
@@ -14,13 +13,6 @@ export const isInternal = (
   id: string,
   context: CommissioningPackageContextProps,
 ) => context.activePackage.internalIds.includes(id);
-export const isInPackage = (
-  id: string,
-  context: CommissioningPackageContextProps,
-) =>
-  context.activePackage.nodeIds
-    ? context.activePackage.nodeIds.includes(assetIri(id))
-    : false;
 
 export function iriFromSvgNode(id: string) {
   return `https://assetid.equinor.com/plantx#${id}`;

--- a/www/src/utils/Triplestore.ts
+++ b/www/src/utils/Triplestore.ts
@@ -26,6 +26,47 @@ export async function makeSparqlAndUpdateStore(
   await queryTripleStore(sparql, Method.Post);
 }
 
+export async function deletePackageFromTripleStore(packageId: string) {
+  const deleteBoundary = "DELETE WHERE { ?boundary comp:isBoundaryOf " + packageId + " . }";
+  const deleteInternal = "DELETE WHERE { ?internal comp:isInPackage " + packageId + " . }";
+  await queryTripleStore(deleteBoundary, Method.Post);
+  await queryTripleStore(deleteInternal, Method.Post);
+}
+
+export async function queryTripleStore(
+  sparql: string,
+  method: Method.Get | Method.Post,
+) {
+  if (method === Method.Get) {
+    try {
+      const encoded = encodeURIComponent(sparql);
+      const response = await fetch(
+        `http://localhost:12110/datastores/boundaries/sparql?query=${encoded}`,
+        {
+          method: "GET",
+        },
+      );
+      return await response.text();
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  } else if (method === Method.Post) {
+    try {
+      await fetch("http://localhost:12110/datastores/boundaries/sparql", {
+        method: "POST",
+        headers: {"Content-Type": "application/x-www-form-urlencoded"},
+        body: `update=${sparql}`,
+      });
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  }
+}
+
+export const assetIri = (id: string) => {
+  return `https://assetid.equinor.com/plantx#${id}`;
+};
+
 export async function addCommissioningPackage(
   packageIri: string,
   packageName: string,
@@ -36,13 +77,6 @@ export async function addCommissioningPackage(
   <${packageIri}> comp:hasName "${packageName}" .
   }`;
   await queryTripleStore(sparql, Method.Post);
-}
-
-export async function deletePackageFromTripleStore(packageId: string) {
-  const deleteBoundary = "DELETE WHERE { ?boundary comp:isBoundaryOf " + packageId + " . }";
-  const deleteInternal = "DELETE WHERE { ?internal comp:isInPackage " + packageId + " . }";
-  await queryTripleStore(deleteBoundary, Method.Post);
-  await queryTripleStore(deleteInternal, Method.Post);
 }
 
 export async function getCommissioningPackage(packageIri: string) {
@@ -86,40 +120,6 @@ function parseCommissioningPackage(result: string, packageIri: string) {
   };
 }
 
-export async function queryTripleStore(
-  sparql: string,
-  method: Method.Get | Method.Post,
-) {
-  if (method === Method.Get) {
-    try {
-      const encoded = encodeURIComponent(sparql);
-      const response = await fetch(
-        `http://localhost:12110/datastores/boundaries/sparql?query=${encoded}`,
-        {
-          method: "GET",
-        },
-      );
-      return await response.text();
-    } catch (error) {
-      console.error("Error:", error);
-    }
-  } else if (method === Method.Post) {
-    try {
-      await fetch("http://localhost:12110/datastores/boundaries/sparql", {
-        method: "POST",
-        headers: {"Content-Type": "application/x-www-form-urlencoded"},
-        body: `update=${sparql}`,
-      });
-    } catch (error) {
-      console.error("Error:", error);
-    }
-  }
-}
-
-export const assetIri = (id: string) => {
-  return `https://assetid.equinor.com/plantx#${id}`;
-};
-
 export async function getAllCommissioningPackages() {
   const query = `
     SELECT ?package ?name ?color WHERE {
@@ -131,11 +131,20 @@ export async function getAllCommissioningPackages() {
   const packages = parseAllCommissioningPackages(result!);
 
   for (const pkg of packages) {
-    const nodeQuery = `SELECT ?node WHERE { ?node comp:isInPackage ${pkg.id} . }`;
+    const nodeQuery = `
+      SELECT ?node ?type WHERE {
+        ?node comp:isInPackage ${pkg.id} .
+        OPTIONAL { ?node comp:isBoundaryOf ${pkg.id} . BIND("boundary" AS ?type) }
+        OPTIONAL { ?node comp:isInPackage ${pkg.id} . BIND("insideBoundary" AS ?type) }
+      }
+    `;
     const nodeResult = await queryTripleStore(nodeQuery, Method.Get);
-    pkg.nodeIds = parseNodeIds(nodeResult!);
+    const { boundaryIds, internalIds } = parseNodeIds(nodeResult!);
+    pkg.boundaryIds = boundaryIds;
+    pkg.internalIds = internalIds;
   }
 
+  console.log(packages);
   return packages;
 }
 
@@ -156,5 +165,17 @@ function parseAllCommissioningPackages(result: string): CommissioningPackage[] {
 
 function parseNodeIds(result: string) {
   const lines = result.split("\n").filter((line) => line.trim() !== "").slice(1);
-  return lines.map((line) => line.replace(/[<>]/g, "").trim());
+  const boundaryIds: string[] = [];
+  const internalIds: string[] = [];
+
+  lines.forEach((line) => {
+    const [nodeId, type] = line.split("\t").map((value) => value.replace(/[<>"]/g, "").trim());
+    if (type === "boundary") {
+      boundaryIds.push(nodeId);
+    } else if (type === "insideBoundary") {
+      internalIds.push(nodeId);
+    }
+  });
+
+  return { boundaryIds, internalIds };
 }

--- a/www/src/utils/Triplestore.ts
+++ b/www/src/utils/Triplestore.ts
@@ -69,7 +69,6 @@ export async function queryTripleStore(
     } catch (error) {
       console.error("Error:", error);
     }
-    console.log("Sparql query sent");
   }
 }
 

--- a/www/src/utils/Triplestore.ts
+++ b/www/src/utils/Triplestore.ts
@@ -54,7 +54,7 @@ export async function deletePackageFromTripleStore(packageId: string) {
 export async function getCommissioningPackage(packageIri: string) {
   const query = `
     SELECT ?node ?name ?color WHERE {
-      OPTIONAL { ?node comp:isInPackage <${packageIri}> . }
+      OPTIONAL { ?node comp:isInPackage ${packageIri} . }
       <${packageIri}> comp:hasName ?name .
       <${packageIri}> comp:hasColor ?color .
     }

--- a/www/src/utils/Triplestore.ts
+++ b/www/src/utils/Triplestore.ts
@@ -22,7 +22,7 @@ export async function makeSparqlAndUpdateStore(
   type: string,
   packageIri: string,
 ) {
-  const sparql = `${action} { <${assetIri(nodeId)}> ${type} ${packageIri} . }`;
+  const sparql = `${action} { <${nodeId}> ${type} ${packageIri} . }`;
   await queryTripleStore(sparql, Method.Post);
 }
 

--- a/www/src/utils/Triplestore.ts
+++ b/www/src/utils/Triplestore.ts
@@ -30,10 +30,10 @@ export async function addCommissioningPackage(
   packageName: string,
   packageColor: HighlightColors,
 ) {
-  let sparql = `INSERT DATA {
+  const sparql = `INSERT DATA {
   <${packageIri}> comp:hasColor "${packageColor}" .
   <${packageIri}> comp:hasName "${packageName}" .
-`;
+  }`;
   await queryTripleStore(sparql, Method.Post);
 }
 

--- a/www/src/utils/Triplestore.ts
+++ b/www/src/utils/Triplestore.ts
@@ -54,7 +54,7 @@ export async function queryTripleStore(
     try {
       await fetch("http://localhost:12110/datastores/boundaries/sparql", {
         method: "POST",
-        headers: {"Content-Type": "application/x-www-form-urlencoded"},
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: `update=${sparql}`,
       });
     } catch (error) {


### PR DESCRIPTION
[Pull requests practices for the SSI team](https://github.com/equinor/ssi-infrastructure/blob/main/docs/pr_practices.md)

## Aim of the PR
This PR fixes [AB#208958](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/208958).

The goal of this PR is to make sure the commissioning packages are persisted and not deleted on refresh of the page.

## Implementation 
Several changes have been made to achieve this:
- Instead of cleaning the triplestore and list of commissioning packages on mount, we get the packages from the triplestore.
- When the app is started and an initial commissioning package is created, the color and name is saved to the triplestore.
- When a user creates a new commissioning package, the color and name is saved to the triplestore.
- Instead of getting just the node Ids from the triplestore, we now get node Id, name and color.
- Added a new "getAllCommissioningPackages" that is called when the page is refreshed. This method gets all commissioning packages, including the name and color.
- Add `SelectedInternal` as type a node can have. This is so that we can save which node was clicked as the internal boundary.

## Type of change
- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

## How Has This Been Tested?
This has been tested by running the demo and testing the UI.

## Additional Changes
I deleted some unused code from `Triplestore.ts` to clean up the file. Let me know if the code that has been removed should be kept there!