### PR TITLE
Docker for dexpi backend

### DIFF
--- a/client/Boundaries/Backend/Dockerfile
+++ b/client/Boundaries/Backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+WORKDIR /app
+COPY . .
+RUN dotnet publish -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+WORKDIR /app
+COPY --from=build /app/out ./
+ENV ASPNETCORE_URLS=http://+:8000
+EXPOSE 8000
+
+ENTRYPOINT ["dotnet", "Backend.dll"]

--- a/client/Boundaries/Backend/Program.cs
+++ b/client/Boundaries/Backend/Program.cs
@@ -7,11 +7,9 @@ builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /app
-COPY . .
+COPY client/Boundaries/Backend/. .
 RUN dotnet publish -c Release -o out
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,16 +22,12 @@ services:
         source: ../
         target: /app/local/
   backend: 
-    build: 
-      context: ..
-      dockerfile: docker/backend/Dockerfile 
+    build:
+      context: ../
+      dockerfile: docker/backend/Dockerfile
     tty: true
     ports:
       -  8000:8000
-    volumes:
-      - type: bind
-        source: client/Boundaries/Backend
-        target: /app
   frontend:
     image: node:23
     working_dir: /app/local/www
@@ -58,6 +54,8 @@ services:
       rml-mapper:
         condition: service_completed_successfully
   symbols:
-    build: ../SymbolLibrary/src
+    build:
+      context: ../
+      dockerfile: docker/symbol-library/Dockerfile
     ports:
       - 5000:5000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,17 @@ services:
       - type: bind
         source: ../
         target: /app/local/
+  backend: 
+    build: 
+      context: ..
+      dockerfile: docker/backend/Dockerfile 
+    tty: true
+    ports:
+      -  8000:8000
+    volumes:
+      - type: bind
+        source: client/Boundaries/Backend
+        target: /app
   frontend:
     image: node:23
     working_dir: /app/local/www

--- a/docker/symbol-library/Dockerfile
+++ b/docker/symbol-library/Dockerfile
@@ -1,7 +1,7 @@
 ﻿FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
-COPY . .
+COPY SymbolLibrary/src/. .
 RUN curl -o /app/Data/Symbols.xlsm https://raw.githubusercontent.com/equinor/NOAKADEXPI/main/Symbols.xlsm
 RUN dotnet publish -c Release -o out
 


### PR DESCRIPTION
## Aim of the PR
This PR fixes [AB#218917](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/218917) 


## Implementation 
Create a docker file for running the backend in a container. Included this in the docker compose file. 

## Type of change
- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

## How Has This Been Tested?
Checked that the docker container ran as expected by checking that the correct endpoints in swagger was displayed when visiting localhosy:8000/swagger