### PR TITLE
Trying out clickable area

### DIFF
--- a/www/src/components/diagram/CenterLine.tsx
+++ b/www/src/components/diagram/CenterLine.tsx
@@ -43,20 +43,22 @@ export default function CenterLine(props: CenterLineComponentProps) {
       {props.centerLines.map((centerline: CenterLineProps, index: number) =>
         centerline !== undefined ? (
           <React.Fragment key={index}>
-            {color && hasSelectedInternalNode && (
+            {(
               <path
+                onClick={() =>
+                    iri ? selectHandleFunction(iri, context, setAction, tool) : {}
+                }
                 id={iri ? iri : props.id}
                 key={index + "_highlight"}
                 d={constructPath(centerline.Coordinate, height)}
-                stroke={color}
+                stroke={color ? color : "#000000"}
                 strokeWidth={5}
+                opacity={hasSelectedInternalNode ? 0.5 : 0}
                 fill={"none"}
               />
             )}
             <StyledPath
-              onClick={() =>
-                iri ? selectHandleFunction(iri, context, setAction, tool) : {}
-              }
+
               key={index}
               d={constructPath(centerline.Coordinate, height)}
               $isDashed={props.isInformationFlow}

--- a/www/src/components/diagram/CenterLine.tsx
+++ b/www/src/components/diagram/CenterLine.tsx
@@ -51,7 +51,7 @@ export default function CenterLine(props: CenterLineComponentProps) {
                 id={iri ? iri : props.id}
                 key={index + "_highlight"}
                 d={constructPath(centerline.Coordinate, height)}
-                stroke={color ? color : "#000000"}
+                stroke={color ? color : "black"}
                 strokeWidth={5}
                 opacity={hasSelectedInternalNode ? 0.5 : 0}
                 fill={"none"}

--- a/www/src/components/diagram/Equipment.tsx
+++ b/www/src/components/diagram/Equipment.tsx
@@ -35,25 +35,26 @@ export default function Equipment(props: EquipmentProps) {
   const isInActivePackage = commissioningPackage
     ? context.activePackage.id === commissioningPackage.id
     : true;
+
   const color = commissioningPackage?.color;
 
   return (
     <>
       <g
         onClick={() =>
-          isInActivePackage
-            ? selectHandleFunction(iri, context, setAction, tool)
-            : {}
+          isInActivePackage ?
+                selectHandleFunction(iri, context, setAction, tool)
+        : {}
         }
       >
         {svg && (
           <>
-            {color && (
+            {(
               <StyledSvgElement
                 id={iri}
                 position={props.Position}
                 svg={svg}
-                color={color}
+                color={color ? color : ""}
               />
             )}
             <g

--- a/www/src/components/diagram/Equipment.tsx
+++ b/www/src/components/diagram/Equipment.tsx
@@ -42,9 +42,9 @@ export default function Equipment(props: EquipmentProps) {
     <>
       <g
         onClick={() =>
-          isInActivePackage ?
-                selectHandleFunction(iri, context, setAction, tool)
-        : {}
+          isInActivePackage
+              ? selectHandleFunction(iri, context, setAction, tool)
+          : {}
         }
       >
         {svg && (

--- a/www/src/components/diagram/Equipment.tsx
+++ b/www/src/components/diagram/Equipment.tsx
@@ -54,7 +54,7 @@ export default function Equipment(props: EquipmentProps) {
                 id={iri}
                 position={props.Position}
                 svg={svg}
-                color={color ? color : ""}
+                color={color ? color : "black"}
               />
             )}
             <g

--- a/www/src/components/diagram/StyledSvgElement.tsx
+++ b/www/src/components/diagram/StyledSvgElement.tsx
@@ -32,15 +32,17 @@ export default function StyledSvgElement({
     pkg.boundaryIds.includes(id) || pkg.internalIds.includes(id),
   );
   let hasSelectedInternalNode: boolean;
+  console.log("HELLO")
   if (commissioningPackage) {
     hasSelectedInternalNode = commissioningPackage.selectedInternalIds.length > 0;
 
     return (
       <>
-        {svg && hasSelectedInternalNode && (
+        {svg && (
           <StyledG
             id={id}
-            color={color}
+            color={hasSelectedInternalNode ? color : "black"}
+            opacity={1}
             transform={
               position
                 ? calculateAngleAndRotation(

--- a/www/src/components/diagram/StyledSvgElement.tsx
+++ b/www/src/components/diagram/StyledSvgElement.tsx
@@ -10,6 +10,7 @@ interface StyledSvgElementProps {
   position?: PositionProps;
   svg: string;
   color: string;
+  onClick?: (id: string) => void;
 }
 
 const StyledG = styled.g`
@@ -25,6 +26,7 @@ export default function StyledSvgElement({
   position,
   svg,
   color,
+  onClick,
 }: StyledSvgElementProps) {
   const height = useContext(PandidContext).height;
   const context = useCommissioningPackageContext();
@@ -33,19 +35,18 @@ export default function StyledSvgElement({
       pkg.boundaryNodes?.some((node) => node.id === id) ||
       pkg.internalNodes?.some((node) => node.id === id),
   );
-  let hasSelectedInternalNode: boolean;
-  console.log("HELLO")
+  let hasSelectedInternalNode: boolean = false;
   if (commissioningPackage) {
     hasSelectedInternalNode =
-      commissioningPackage.selectedInternalNodes.length > 0;
-
+        commissioningPackage.selectedInternalNodes.length > 0;
+  }
     return (
       <>
         {svg && (
           <StyledG
             id={id}
-            color={hasSelectedInternalNode ? color : "black"}
-            opacity={1}
+            color={color}
+            opacity={hasSelectedInternalNode ? 0.5 : 0}
             transform={
               position
                 ? calculateAngleAndRotation(
@@ -58,11 +59,12 @@ export default function StyledSvgElement({
             }
             className={".node"}
             dangerouslySetInnerHTML={{ __html: svg }}
+            onClick={() => onClick && onClick(id)}
           />
         )}
       </>
     );
-  }
 
-  return null;
+
+  //return null;
 }


### PR DESCRIPTION

## Aim of the PR
This PR fixes [AB#208959](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/208959).

Make it easier to click on components and lines

## Implementation 
Changed the StyledSvgElement and path that has the highlight to always be rendered, just with opacity 0 when not selected. Then this larger area is always clickable. Also moved the onClick in StyledPath to be in the path (which has the highlight) for centerlines.

## Type of change
- [ ] Bug fix 
- [x] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

If the changes impact any dependent services then provide details.
## How Has This Been Tested?
Tried locally on Firefox in Ubuntu