### PR TITLE
Feat 226539: use mocked graphical data

### DIFF
--- a/client/Boundaries/Backend/Endpoints/GraphicalDataFormatEndpoints.cs
+++ b/client/Boundaries/Backend/Endpoints/GraphicalDataFormatEndpoints.cs
@@ -11,8 +11,7 @@ public static class GraphicalDataFormatEndpoints
 
             // return example file
             var filePath = Path.Combine(AppContext.BaseDirectory, "Example", "graphical-data-format-example.json");
-            var jsonContent = await File.ReadAllTextAsync(filePath);
-            return Results.Json(jsonContent);
+            return Results.Stream(File.OpenRead(filePath), "application/json");
         }).WithTags("Graphical Data Format");
 
         // Get all P&ID graphical data formats

--- a/client/Boundaries/Backend/Example/graphical-data-format-example.json
+++ b/client/Boundaries/Backend/Example/graphical-data-format-example.json
@@ -39,9 +39,9 @@
             }
         ],
         "style": {
-            "stroke-dasharray": "none",
-            "stroke-width": "1,4",
-            "stroke": "rgb(255,255,255)"
+            "strokeDasharray": "none",
+            "strokeWidth": "0.25",
+            "stroke": "rgb(0,0,0)"
         }
         }
     ]

--- a/www/src/components/diagram/LinesGraphicalDataExample.tsx
+++ b/www/src/components/diagram/LinesGraphicalDataExample.tsx
@@ -1,0 +1,79 @@
+import { useContext } from "react";
+import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
+import ToolContext from "../../context/ToolContext.ts";
+import ActionContext from "../../context/ActionContext.ts";
+import {
+  LineProps,
+  PointProps,
+} from "../../types/diagram/GraphicalDataFormatTestTypes.ts";
+import selectHandleFunction from "../../utils/CommissioningPackageHandler.tsx";
+import { isBoundary, isSelectedInternal } from "../../utils/HelperFunctions.ts";
+
+function constructLine(coordinates: PointProps[]) {
+  let dString = "M ";
+  for (let i = 0; i < coordinates.length; i++) {
+    const coordinate = coordinates[i];
+    dString += `${coordinate.x} ${coordinate.y}`;
+    if (i !== coordinates.length - 1) {
+      dString += ` L `;
+    }
+  }
+  return dString;
+}
+
+export default function Line({ id, style, coordinates }: LineProps) {
+  const context = useCommissioningPackageContext();
+  const setAction = useContext(ActionContext).setAction;
+  const tool = useContext(ToolContext).activeTool;
+  const commissioningPackage = context.commissioningPackages.find(
+    (pkg) =>
+      pkg.boundaryNodes?.some((node) => node.id === id) ||
+      pkg.internalNodes?.some((node) => node.id === id),
+  );
+  const isInActivePackage = commissioningPackage
+    ? context.activePackage.id === commissioningPackage.id
+    : true;
+  const color = commissioningPackage?.color;
+
+  function calculateLineColor() {
+    if (isBoundary(id, context)) {
+      return "green";
+    } else if (isSelectedInternal(id, context)) {
+      return "red";
+    } else {
+      return style.stroke;
+    }
+  }
+  return (
+    <g
+      onClick={() =>
+        isInActivePackage
+          ? selectHandleFunction(id, context, setAction, tool)
+          : {}
+      }
+    >
+      <path
+        id={id}
+        key={id + "_highlight"}
+        d={constructLine(coordinates)}
+        stroke={color ? color : "white"}
+        opacity={color ? 1 : 0}
+        strokeWidth={5}
+        strokeDasharray={style.strokeDasharray}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill={"none"}
+      />
+      <path
+        id={id}
+        key={id}
+        d={constructLine(coordinates)}
+        stroke={calculateLineColor()}
+        strokeWidth={style.strokeWidth}
+        strokeDasharray={style.strokeDasharray}
+        className={`${isBoundary(id, context) ? "boundary" : ""} ${isSelectedInternal(id, context) ? "selectedInternal" : ""}`}
+        fill={"none"}
+      />
+    </g>
+  );
+}

--- a/www/src/components/diagram/LinesGraphicalDataExample.tsx
+++ b/www/src/components/diagram/LinesGraphicalDataExample.tsx
@@ -44,6 +44,14 @@ export default function Line({ id, style, coordinates }: LineProps) {
       return style.stroke;
     }
   }
+
+  function calculateLineWeight() {
+    if (isBoundary(id, context) || isSelectedInternal(id, context)) {
+      return 0.6;
+    } else {
+      return style.strokeWidth;
+    }
+  }
   return (
     <g
       onClick={() =>
@@ -69,7 +77,7 @@ export default function Line({ id, style, coordinates }: LineProps) {
         key={id}
         d={constructLine(coordinates)}
         stroke={calculateLineColor()}
-        strokeWidth={style.strokeWidth}
+        strokeWidth={calculateLineWeight()}
         strokeDasharray={style.strokeDasharray}
         className={`${isBoundary(id, context) ? "boundary" : ""} ${isSelectedInternal(id, context) ? "selectedInternal" : ""}`}
         fill={"none"}

--- a/www/src/components/diagram/PandIdGraphicalDataExample.tsx
+++ b/www/src/components/diagram/PandIdGraphicalDataExample.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
+import styled from "styled-components";
+import ZoomableSVGWrapper from "../editor/ZoomableSVGWrapper.tsx";
+import {
+  getAllCommissioningPackages,
+  getGraphicalData,
+} from "../../utils/Api.ts";
+import SymbolGraphicalDataExample from "./SymbolGraphicalDataExample.tsx";
+import { DiagramProps } from "../../types/diagram/GraphicalDataFormatTestTypes.ts";
+import Line from "./LinesGraphicalDataExample.tsx";
+
+const SVGContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+export default function PandIdGraphicalDataExample() {
+  const context = useCommissioningPackageContext();
+  const [graphicalData, setGraphicalData] = useState<DiagramProps>();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Step 1: Fetch existing commissioning packages
+  useEffect(() => {
+    (async () => {
+      const packages = await getAllCommissioningPackages();
+      const graphicalDataTest = await getGraphicalData("test");
+      setGraphicalData(graphicalDataTest);
+      context.setCommissioningPackages(packages);
+      if (packages[0]) context.setActivePackage(packages[0]);
+    })();
+  }, []);
+
+  return (
+    <SVGContainer ref={containerRef}>
+      {graphicalData && (
+        <ZoomableSVGWrapper
+          containerRef={containerRef as React.RefObject<HTMLDivElement>}
+        >
+          <svg
+            viewBox={`${graphicalData.extent.min.x} ${graphicalData.extent.min.y} ${graphicalData.extent.max.x} ${graphicalData.extent.max.y}`}
+            width={"100%"}
+            height={"100%"}
+          >
+            {graphicalData.symbols.map((symbol, index) => (
+              <SymbolGraphicalDataExample key={index} {...symbol} />
+            ))}
+            {graphicalData.lines.map((line, index) => (
+              <Line key={index} {...line} />
+            ))}
+          </svg>
+        </ZoomableSVGWrapper>
+      )}
+    </SVGContainer>
+  );
+}

--- a/www/src/components/diagram/SymbolGraphicalDataExample.tsx
+++ b/www/src/components/diagram/SymbolGraphicalDataExample.tsx
@@ -1,0 +1,56 @@
+import { useContext } from "react";
+import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
+import { isBoundary, isSelectedInternal } from "../../utils/HelperFunctions.ts";
+import ToolContext from "../../context/ToolContext.ts";
+import selectHandleFunction from "../../utils/CommissioningPackageHandler.tsx";
+import ActionContext from "../../context/ActionContext.ts";
+import { SymbolProps } from "../../types/diagram/GraphicalDataFormatTestTypes.ts";
+import styled from "styled-components";
+
+const StyledG = styled.g`
+  path {
+    stroke: ${(props) => props.color};
+    stroke-width: 5;
+    opacity: 1;
+  }
+`;
+
+export default function Symbol(props: SymbolProps) {
+  const context = useCommissioningPackageContext();
+  const setAction = useContext(ActionContext).setAction;
+  const tool = useContext(ToolContext).activeTool;
+  const commissioningPackage = context.commissioningPackages.find(
+    (pkg) =>
+      pkg.boundaryNodes?.some((node) => node.id === props.id) ||
+      pkg.internalNodes?.some((node) => node.id === props.id),
+  );
+  const isInActivePackage = commissioningPackage
+    ? context.activePackage.id === commissioningPackage.id
+    : true;
+  const color = commissioningPackage?.color;
+
+  return (
+    <g
+      onClick={() =>
+        isInActivePackage
+          ? selectHandleFunction(props.id, context, setAction, tool)
+          : {}
+      }
+    >
+      <StyledG
+        id={props.id + "_highlight"}
+        color={color ? color : "white"}
+        opacity={color ? 1 : 0}
+        transform={`rotate(${props.position.rotation}) translate(${props.position.x}, ${props.position.y})`}
+        className={`.node ${isBoundary(props.id, context) ? "boundary" : ""} ${isSelectedInternal(props.id, context) ? "selectedInternal" : ""}`}
+        dangerouslySetInnerHTML={{ __html: props.svg }}
+      />
+      <g
+        id={props.id}
+        transform={`rotate(${props.position.rotation}) translate(${props.position.x}, ${props.position.y})`}
+        className={`.node ${isBoundary(props.id, context) ? "boundary" : ""} ${isSelectedInternal(props.id, context) ? "selectedInternal" : ""}`}
+        dangerouslySetInnerHTML={{ __html: props.svg }}
+      />
+    </g>
+  );
+}

--- a/www/src/components/editor/Editor.tsx
+++ b/www/src/components/editor/Editor.tsx
@@ -9,7 +9,8 @@ import EditorTopBar from "./EditorTopBar.tsx";
 import styled from "styled-components";
 import ActionContext from "../../context/ActionContext.ts";
 import NodeTable from "../tables/NodeTable.tsx";
-import {SideSheet} from "@equinor/eds-core-react";
+import { SideSheet } from "@equinor/eds-core-react";
+import PandIdGraphicalDataExample from "../diagram/PandIdGraphicalDataExample.tsx";
 
 const EditorContainer = styled.div`
   height: 100%;
@@ -36,15 +37,18 @@ export default function Editor() {
           <EditorContainer>
             <EditorTopBar />
             <SideBarAndPandid>
-              <EditorSidebar tableIsVisible={tableIsVisible} setTableIsVisible={setTableIsVisible} />
-              <Pandid />
+              <EditorSidebar
+                tableIsVisible={tableIsVisible}
+                setTableIsVisible={setTableIsVisible}
+              />
+              <PandIdGraphicalDataExample />
             </SideBarAndPandid>
           </EditorContainer>
         </ActionContext.Provider>
       </ToolContext.Provider>
-        <SideSheet open={tableIsVisible}>
-            <NodeTable/>
-        </SideSheet>
+      <SideSheet open={tableIsVisible}>
+        <NodeTable />
+      </SideSheet>
     </CommissioningPackageContextProvider>
   );
 }

--- a/www/src/components/editor/Editor.tsx
+++ b/www/src/components/editor/Editor.tsx
@@ -30,6 +30,7 @@ export default function Editor() {
   const [activeTool, setActiveTool] = useState(Tools.BOUNDARY);
   const [action, setAction] = useState<Action>({ tool: null, node: "" });
   const [tableIsVisible, setTableIsVisible] = useState(false);
+  const [isNewGraphics, setIsNewGraphics] = useState(false);
   return (
     <CommissioningPackageContextProvider>
       <ToolContext.Provider value={{ activeTool, setActiveTool }}>
@@ -40,8 +41,10 @@ export default function Editor() {
               <EditorSidebar
                 tableIsVisible={tableIsVisible}
                 setTableIsVisible={setTableIsVisible}
+                isNewGraphics={isNewGraphics}
+                setIsNewGraphics={setIsNewGraphics}
               />
-              <PandIdGraphicalDataExample />
+              {isNewGraphics ? <PandIdGraphicalDataExample /> : <Pandid />}
             </SideBarAndPandid>
           </EditorContainer>
         </ActionContext.Provider>

--- a/www/src/components/editor/EditorSidebar.tsx
+++ b/www/src/components/editor/EditorSidebar.tsx
@@ -1,131 +1,146 @@
-import {SideBar, SidebarLinkProps} from "@equinor/eds-core-react";
+import { SideBar, SidebarLinkProps } from "@equinor/eds-core-react";
 import {
-    add,
-    undo,
-    redo,
-    boundaries,
-    category,
-    texture,
-    delete_to_trash,
-    table_chart
+  add,
+  undo,
+  redo,
+  boundaries,
+  category,
+  texture,
+  delete_to_trash,
+  table_chart,
+  switch_on,
 } from "@equinor/eds-icons";
 import styled from "styled-components";
-import React, {useContext, useState} from "react";
+import React, { useContext, useState } from "react";
 import Tools from "../../enums/Tools.ts";
-import {useCommissioningPackageContext} from "../../hooks/useCommissioningPackageContext.tsx";
+import { useCommissioningPackageContext } from "../../hooks/useCommissioningPackageContext.tsx";
 import ToolContext from "../../context/ToolContext.ts";
 import CommissioningPackageCreationDialog from "./CommissioningPackageCreationDialog.tsx";
 import CommissioningPackageDeletionDialog from "./CommissioningPackageDeletionDialog.tsx";
 import useUndoRedo from "../../hooks/useUndoRedo.tsx";
 
 const StyledSideBar = styled.div`
-    height: 100%;
+  height: 100%;
 `;
 
 interface EditorSidebarProps {
-    tableIsVisible: boolean,
-    setTableIsVisible: React.Dispatch<React.SetStateAction<boolean>>
+  tableIsVisible: boolean;
+  setTableIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  isNewGraphics: boolean;
+  setIsNewGraphics: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function EditorSidebar({tableIsVisible, setTableIsVisible}: EditorSidebarProps) {
-    const context = useCommissioningPackageContext();
-    const {handleUndo, handleRedo} = useUndoRedo();
-    const {activeTool, setActiveTool} = useContext(ToolContext);
-    const [isCreationOpen, setIsCreationOpen] = useState<boolean>(false);
-    const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
+export default function EditorSidebar({
+  tableIsVisible,
+  setTableIsVisible,
+  isNewGraphics,
+  setIsNewGraphics,
+}: EditorSidebarProps) {
+  const context = useCommissioningPackageContext();
+  const { handleUndo, handleRedo } = useUndoRedo();
+  const { activeTool, setActiveTool } = useContext(ToolContext);
+  const [isCreationOpen, setIsCreationOpen] = useState<boolean>(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
 
-    const menuItemsInitial: SidebarLinkProps[] = [
-        {
-            label: "Select boundaries",
-            icon: boundaries,
-            onClick: () => {
-                setActiveTool(Tools.BOUNDARY);
-            },
-            active: activeTool === Tools.BOUNDARY,
-        },
-        {
-            label: "Select inside of boundary",
-            icon: texture,
-            onClick: () => {
-                setActiveTool(Tools.INSIDEBOUNDARY);
-            },
-            active: activeTool === Tools.INSIDEBOUNDARY,
-        },
-        {
-            label: "Undo",
-            icon: undo,
-            onClick: async () => {
-                await handleUndo();
-            },
-            active: false,
-        },
-        {
-            label: "Redo",
-            icon: redo,
-            onClick: async () => {
-                await handleRedo();
-            },
-            active: false,
-        },
-        {
-            label: "Delete commissioning packages",
-            icon: delete_to_trash,
-            onClick: () => {
-                setIsDeleteOpen(true);
-            },
-        },
-        {
-            label: "Hide or show table of tags in active package",
-            icon: table_chart,
-            onClick: () => {
-                setTableIsVisible(!tableIsVisible);
-            },
-        },
-    ];
+  const menuItemsInitial: SidebarLinkProps[] = [
+    {
+      label: "Select boundaries",
+      icon: boundaries,
+      onClick: () => {
+        setActiveTool(Tools.BOUNDARY);
+      },
+      active: activeTool === Tools.BOUNDARY,
+    },
+    {
+      label: "Select inside of boundary",
+      icon: texture,
+      onClick: () => {
+        setActiveTool(Tools.INSIDEBOUNDARY);
+      },
+      active: activeTool === Tools.INSIDEBOUNDARY,
+    },
+    {
+      label: "Undo",
+      icon: undo,
+      onClick: async () => {
+        await handleUndo();
+      },
+      active: false,
+    },
+    {
+      label: "Redo",
+      icon: redo,
+      onClick: async () => {
+        await handleRedo();
+      },
+      active: false,
+    },
+    {
+      label: "Delete commissioning packages",
+      icon: delete_to_trash,
+      onClick: () => {
+        setIsDeleteOpen(true);
+      },
+    },
+    {
+      label: "Hide or show table of tags in active package",
+      icon: table_chart,
+      onClick: () => {
+        setTableIsVisible(!tableIsVisible);
+      },
+    },
+    {
+      label: "Toggle new graphical format",
+      icon: switch_on,
+      onClick: () => {
+        setIsNewGraphics(!isNewGraphics);
+      },
+    },
+  ];
 
-    return (
-        <>
-            <CommissioningPackageCreationDialog
-                open={isCreationOpen}
-                setOpen={setIsCreationOpen}
+  return (
+    <>
+      <CommissioningPackageCreationDialog
+        open={isCreationOpen}
+        setOpen={setIsCreationOpen}
+      />
+      <CommissioningPackageDeletionDialog
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+      />
+      <StyledSideBar>
+        <SideBar>
+          <SideBar.Content>
+            <SideBar.Button
+              icon={add}
+              onClick={() => {
+                setIsCreationOpen(true);
+              }}
+              label={"Create new commissioning package"}
             />
-            <CommissioningPackageDeletionDialog
-                isOpen={isDeleteOpen}
-                onClose={() => setIsDeleteOpen(false)}
-            />
-            <StyledSideBar>
-                <SideBar>
-                    <SideBar.Content>
-                        <SideBar.Button
-                            icon={add}
-                            onClick={() => {
-                                setIsCreationOpen(true);
-                            }}
-                            label={"Create new commissioning package"}
-                        />
-                        {context?.commissioningPackages && (
-                            <SideBar.Accordion
-                                label={"Commissioning packages"}
-                                icon={category}
-                            >
-                                {context.commissioningPackages.map((commpckg) => (
-                                    <SideBar.AccordionItem
-                                        label={commpckg.name}
-                                        key={commpckg.name}
-                                        onClick={() => {
-                                            context?.setActivePackage(commpckg);
-                                        }}
-                                    />
-                                ))}
-                            </SideBar.Accordion>
-                        )}
+            {context?.commissioningPackages && (
+              <SideBar.Accordion
+                label={"Commissioning packages"}
+                icon={category}
+              >
+                {context.commissioningPackages.map((commpckg) => (
+                  <SideBar.AccordionItem
+                    label={commpckg.name}
+                    key={commpckg.name}
+                    onClick={() => {
+                      context?.setActivePackage(commpckg);
+                    }}
+                  />
+                ))}
+              </SideBar.Accordion>
+            )}
 
-                        {menuItemsInitial.map((item, index) => (
-                            <SideBar.Link key={index} {...item} />
-                        ))}
-                    </SideBar.Content>
-                </SideBar>
-            </StyledSideBar>
-        </>
-    );
+            {menuItemsInitial.map((item, index) => (
+              <SideBar.Link key={index} {...item} />
+            ))}
+          </SideBar.Content>
+        </SideBar>
+      </StyledSideBar>
+    </>
+  );
 }

--- a/www/src/types/diagram/GraphicalDataFormatTestTypes.ts
+++ b/www/src/types/diagram/GraphicalDataFormatTestTypes.ts
@@ -1,0 +1,38 @@
+export interface PointProps {
+  x: number;
+  y: number;
+}
+
+export interface ExtentProps {
+  min: PointProps;
+  max: PointProps;
+}
+
+export interface SymbolProps {
+  id: string;
+  position: PositionProps;
+  svg: string;
+}
+
+export interface PositionProps extends PointProps {
+  rotation: number;
+}
+
+export interface LineProps {
+  id: string;
+  coordinates: PointProps[];
+  style: LineStyleProps;
+}
+
+export interface LineStyleProps {
+  strokeDasharray: string;
+  strokeWidth: string;
+  stroke: string;
+}
+
+export interface DiagramProps {
+  diagramName: string;
+  extent: ExtentProps;
+  symbols: SymbolProps[];
+  lines: LineProps[];
+}

--- a/www/src/utils/Api.ts
+++ b/www/src/utils/Api.ts
@@ -1,4 +1,5 @@
 import CommissioningPackage from "../types/CommissioningPackage.ts";
+import { DiagramProps } from "../types/diagram/GraphicalDataFormatTestTypes.ts";
 
 const BASE_URL = "http://localhost:8000";
 
@@ -90,4 +91,15 @@ export const updateInternal = async (packageId: string, nodeId: string) => {
     `${BASE_URL}/commissioning-package/${encodeURIComponent(packageId)}/update-internal/${encodeURIComponent(nodeId)}`,
     { method: "POST" },
   );
+};
+
+// GRAPHICS
+
+export const getGraphicalData = async (
+  documentId: string,
+): Promise<DiagramProps> => {
+  const response = await fetch(
+    `${BASE_URL}/graphical-data-format/${encodeURIComponent(documentId)}`,
+  );
+  return response.json();
 };


### PR DESCRIPTION
## Aim of the PR
This PR fixes [AB#226539](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/226539)

We are creating a new graphical format that sends data to the frontend in the form of JSON. This PR aims to start creating components and functions that fetch such data and displays it.

## Implementation 
There are two new components:
- **LinesGraphicalDataExample.tsx**: This component handles lines, both dashed and normal.
- **SymbolGraphicalDataExample.tsx**: This component handles equipment, nozzles, pipingcomponents etc. Everything that has an SVG is a symbol and handled by this component.

In addition, a modified Pandid-component is created for testing:
**PandIdGraphicalDataExample.tsx**: Fetches graphical data from the endpoint and loops over all lines and symbols to display them.

New interfaces have been created for the new format.

## Type of change
- [ ] Bug fix 
- [X] New feature 
- [ ] Breaking change 
- [ ] This change requires a documentation update

If the changes impact any dependent services then provide details.
## How Has This Been Tested?
Tested by visually confirming that both symbols and lines are rendered in the editor and are clickable, both as internal and boundary.

## Additional Changes
- The graphical data endpoint returned the JSON as a string instead of pure JSON. Changed this endpoint to return JSON.
- Changed graphical data format example style names to match JavaScript variable naming conventions.