### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/symbol_translator_tester.yml
+++ b/.github/workflows/symbol_translator_tester.yml
@@ -1,4 +1,6 @@
 name: "Run tests (required)"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
This PR fixes [AB#379924](https://dev.azure.com/EquinorASA/bb9bd8cb-74f7-4ffa-b0cb-60eff0a0be58/_workitems/edit/379924)

Potential fix for [https://github.com/equinor/Dexpi2Imf/security/code-scanning/3](https://github.com/equinor/Dexpi2Imf/security/code-scanning/3)

**How to fix:**  
Add a `permissions` block to the root of the workflow (before `jobs:`) specifying the least privilege required, per GitHub recommendations. For most CI jobs that build and test code but do not require repository modifications, this should be `permissions: contents: read`. This ensures the GITHUB_TOKEN used in the workflow only allows reading repository content, reducing the risk if a workflow step is compromised.

**Implementation:**  
Insert the following YAML block after the workflow name and before the `on:` and/or `jobs:` blocks, as per standard YAML formatting:
```yaml
permissions:
  contents: read
```
This should be inserted at the root level, typically after the `name` field and before `on:` or `jobs:`. For clarity, in this workflow, place it after `name:` and before `on:`. No changes to imports, methods, or additional configuration are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
